### PR TITLE
docs: actual should come first in assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const disallowUnencrytpedS3 = {
     description: "Checks whether S3 buckets have encryption turned on.",
     enforcementLevel: "mandatory",
     rules: typedRule(aws.s3.Bucket.isInstance, it => {
-        assert.notStrictEqual(undefined, it.serverSideEncryptionConfiguration);
+        assert.notStrictEqual(it.serverSideEncryptionConfiguration, undefined);
     }),
 }
 ```


### PR DESCRIPTION
In an assert(), the actual is supposed to come before the expected.