### PR TITLE
Cleanup comments

### DIFF
--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -35,11 +35,8 @@ export class PolicyPack {
     constructor(private name: string, args: PolicyPackArgs) {
         this.policies = args.policies;
 
-        //
         // TODO: Wire up version information obtained from the service.
-        //
         const version = "1";
-
         serve(this.name, version, this.policies);
     }
 }
@@ -55,7 +52,7 @@ export type EnforcementLevel = "advisory" | "mandatory";
  * is violated.
  */
 export interface Policy {
-    /** An ID for the policy. Must be unique to the current policy set. */
+    /** An ID for the policy. Must be unique within the current policy set. */
     name: string;
 
     /**

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -48,8 +48,19 @@ import { version } from "./version";
 
 // ------------------------------------------------------------------------------------------------
 
+// Flag indicating whether or not a gRPC service is currently running for this process.
 let serving = false;
 
+/**
+ * Starts the gRPC server to communicate with the Pulumi CLI client for analyzing resources.
+ *
+ * Only one gRPC server can be running at a time, and the port the server is running on will
+ * be written to STDOUT.
+ *
+ * @param policyPackName Friendly name of the policy pack.
+ * @param policyPackVersion Version of the policy pack SDK used.
+ * @param policies The policies to be served.
+ */
 export function serve(policyPackName: string, policyPackVersion: string, policies: Policies): void {
     if (serving !== false) {
         throw Error("Only one policy gRPC server can run per process");


### PR DESCRIPTION
Add some comments to important things that were missing them, and correct comments that were no longer accurate. e.g. "A function that returns true if a resource definition violates some policy." should now be "A function that throws an `AssertionError` if a resource definition violates some policy."