### PR TITLE
API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 vendor/
 **/Pulumi.*.yaml
 **/yarn-error.log
-yarn.lock
+**/yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ before_install:
     - source ${GOPATH}/src/github.com/pulumi/scripts/ci/prepare-environment.sh
     - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
 install:
+    # Install Pulumi 🍹
+    - curl -fsSL https://get.pulumi.com/ | bash
+    - export PATH="$HOME/.pulumi/bin:$PATH"
+    # Install other tools.
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
 before_script:
     - ${PULUMI_SCRIPTS}/ci/ensure-dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## 0.1.2 (unreleased)
 
+### Improvements
+
+- API changes to enable new types of policies (i.e. validating all resource in a stack) and passing
+  additional information to validation functions (https://github.com/pulumi/pulumi-policy/pull/131).
+
+  - `Policy.rules` is now `ResourceValidationPolicy.validateResource`.
+  - `typedRule` is now `validateTypedResource`.
+  - Policy violations are now reported through a `reportViolation` callback, rather than using asserts.
+  - A new `StackValidationPolicy` policy type is available for defining policies that check all resources
+    in a stack (the API definition is available, but such policies are not enabled yet).
+  - Validation functions can now return `Promise<void>`.
+
+  Example:
+
+  ```typescript
+  new PolicyPack("aws-policy-pack", {
+      policies: [{
+          name: "s3-no-public-read",
+          description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+          enforcementLevel: "mandatory",
+          validateResource: validateTypedResource(aws.s3.Bucket.isInstance, (it, args, reportViolation) => {
+              if (it.acl === "public-read" || it.acl === "public-read-write") {
+                  reportViolation(
+                      "You cannot set public-read or public-read-write on an S3 bucket. " +
+                      "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");
+              }
+          }),
+      }],
+  });
+  ```
+
 ### Bug fixes
 
 - Allow policies to deal with Pulumi secret values

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ PROJECT_NAME := policy
 SUB_PROJECTS := sdk/nodejs/policy
 include build/common.mk
 
+.PHONY: ensure
+ensure::
+	# Golang dependencies for the integration tests.
+	go get -t -d ./tests/integration
+
 .PHONY: publish_packages
 publish_packages:
 	$(call STEP_MESSAGE)
@@ -10,6 +15,10 @@ publish_packages:
 .PHONY: check_clean_worktree
 check_clean_worktree:
 	$$(go env GOPATH)/src/github.com/pulumi/scripts/ci/check-worktree-is-clean.sh
+
+.PHONY: test
+test:
+	go test .tests/integration -v -timeout 30m
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -133,9 +133,10 @@ export function validateTypedResource<TResource extends Resource>(
 ): ResourceValidation {
     return (args: ResourceValidationArgs, reportViolation: ReportViolation) => {
         args.props.__pulumiType = args.type;
-        if (typeFilter(args.props)) {
-            return validate(args.props, args, reportViolation);
+        if (typeFilter(args.props) === false) {
+            return;
         }
+        validate(args.props as q.ResolvedResource<TResource>, args, reportViolation);
     };
 }
 
@@ -150,7 +151,10 @@ export function asTypedResource<TResource extends Resource>(
     args: { type: string, props: Record<string, any> },
 ): q.ResolvedResource<TResource> | undefined {
     args.props.__pulumiType = args.type;
-    return typeFilter(args.props) ? args.props : undefined;
+    if (typeFilter(args.props) === false) {
+        return undefined;
+    }
+    return args.props as q.ResolvedResource<TResource>;
 }
 
 /**

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -121,11 +121,11 @@ export interface ResourceValidationArgs {
 
 /**
  * A helper function that returns a strongly-typed resource validation function.
- * @param filter A type guard used to determine if the args are an instance of the resource.
+ * @param typeFilter A type guard used to determine if the args are an instance of the resource.
  * @param validate A callback function that validates if the resource definition violates a policy.
  */
 export function validateTypedResource<TResource extends Resource>(
-    filter: (o: any) => o is TResource,
+    typeFilter: (o: any) => o is TResource,
     validate: (
         resource: q.ResolvedResource<TResource>,
         args: ResourceValidationArgs,
@@ -133,7 +133,7 @@ export function validateTypedResource<TResource extends Resource>(
 ): ResourceValidation {
     return (args: ResourceValidationArgs, reportViolation: ReportViolation) => {
         args.props.__pulumiType = args.type;
-        if (filter(args.props)) {
+        if (typeFilter(args.props)) {
             return validate(args.props, args, reportViolation);
         }
     };
@@ -142,15 +142,15 @@ export function validateTypedResource<TResource extends Resource>(
 /**
  * A helper function that returns `props` as a strongly-typed resolved resource based
  * on the specified `type` when `filter` returns true, otherwise `undefined` is returned.
- * @param filter A type guard used to determine if the args are an instance of the resource.
+ * @param typeFilter A type guard used to determine if the args are an instance of the resource.
  * @param args Argument bag for specifying the `type` and `props`.
  */
 export function asTypedResource<TResource extends Resource>(
-    filter: (o: any) => o is TResource,
+    typeFilter: (o: any) => o is TResource,
     args: { type: string, props: Record<string, any> },
 ): q.ResolvedResource<TResource> | undefined {
     args.props.__pulumiType = args.type;
-    return filter(args.props) ? args.props : undefined;
+    return typeFilter(args.props) ? args.props : undefined;
 }
 
 /**

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -12,17 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as pulumi from "@pulumi/pulumi";
 import { Resource } from "@pulumi/pulumi";
 import * as q from "@pulumi/pulumi/queryable";
 import { serve } from "./server";
 
+/**
+ * The set of arguments for constructing a PolicyPack.
+ */
 export interface PolicyPackArgs {
-    policies: Policy[];
+    /**
+     * The policies associated with a PolicyPack.
+     */
+    policies: Policies;
 }
 
+/**
+ * A PolicyPack contains one or more policies to enforce.
+ */
 export class PolicyPack {
-    private readonly policies: Policy[];
+    private readonly policies: Policies;
 
     constructor(private name: string, args: PolicyPackArgs) {
         this.policies = args.policies;
@@ -35,27 +43,6 @@ export class PolicyPack {
         serve(this.name, version, this.policies);
     }
 }
-
-/** A function that returns true if a resource definition violates some policy. */
-export type Rule = (type: string, properties: any) => void;
-
-export function typedRule<TResource extends pulumi.Resource>(
-    filter: (o: any) => o is TResource,
-    rule: (properties: q.ResolvedResource<TResource>) => void,
-): Rule {
-    return (type: string, properties: any) => {
-        properties.__pulumiType = type;
-        if (filter(properties) === false) {
-            return;
-        }
-        return rule(properties);
-    };
-}
-
-/**
- * A keyword or term to associate with a policy, such as "cost" or "security."
- */
-export type Tag = string;
 
 /**
  * Indicates the impact of a policy violation.
@@ -82,10 +69,142 @@ export interface Policy {
      * proper permissions.
      */
     enforcementLevel: EnforcementLevel;
+}
+
+/**
+ * An array of Policies.
+ */
+export type Policies = (ResourceValidationPolicy | StackValidationPolicy)[];
+
+/**
+ * ResourceValidationPolicy is a policy that validates a resource definition.
+ */
+export interface ResourceValidationPolicy extends Policy {
+    /**
+     * A callback function that validates if a resource definition violates a policy (e.g. "S3 buckets
+     * can't be public"). A single callback function can be specified, or multiple functions, which are
+     * called in order.
+     */
+    validateResource: ResourceValidation | ResourceValidation[];
+}
+
+/**
+ * ResourceValidation is the callback signature for a `ResourceValidationPolicy`. A resource validation
+ * is passed `args` with more information about the resource and a `reportViolation` callback that can be
+ * used to report a policy violation. `reportViolation` can be called multiple times to report multiple
+ * violations against the same resource. `reportViolation` must be passed a message about the violation.
+ * The `reportViolation` signature accepts an optional `urn` argument, which is ignored when validating
+ * resources (the `urn` of the resource being validated is always used).
+ */
+export type ResourceValidation = (args: ResourceValidationArgs, reportViolation: ReportViolation) => Promise<void> | void;
+
+/**
+ * ResourceValidationArgs is the argument bag passed to a resource validation.
+ */
+export interface ResourceValidationArgs {
+    /**
+     * The type of the Resource.
+     */
+    type: string;
 
     /**
-     * Chain of rules that return true if a resource definition violates a policy (e.g., "S3 buckets
-     * can't be public"). Rules are applied in the order they are declared.
+     * The properties of the Resource.
      */
-    rules: Rule | Rule[];
+    props: Record<string, any>;
+
+    // TODO: Add support for the following:
+    //
+    // urn: string;
+    // name: string;
+    // opts: PolicyResourceOptions;
 }
+
+/**
+ * A helper function that returns a strongly-typed resource validation function.
+ * @param filter A type guard used to determine if the args are an instance of the resource.
+ * @param validate A callback function that validates if the resource definition violates a policy.
+ */
+export function validateTypedResource<TResource extends Resource>(
+    filter: (o: any) => o is TResource,
+    validate: (
+        resource: q.ResolvedResource<TResource>,
+        args: ResourceValidationArgs,
+        reportViolation: ReportViolation) => Promise<void> | void,
+): ResourceValidation {
+    return (args: ResourceValidationArgs, reportViolation: ReportViolation) => {
+        args.props.__pulumiType = args.type;
+        if (filter(args.props)) {
+            return validate(args.props, args, reportViolation);
+        }
+    };
+}
+
+/**
+ * A helper function that returns `props` as a strongly-typed resolved resource based
+ * on the specified `type` when `filter` returns true, otherwise `undefined` is returned.
+ * @param filter A type guard used to determine if the args are an instance of the resource.
+ * @param args Argument bag for specifying the `type` and `props`.
+ */
+export function asTypedResource<TResource extends Resource>(
+    filter: (o: any) => o is TResource,
+    args: { type: string, props: Record<string, any> },
+): q.ResolvedResource<TResource> | undefined {
+    args.props.__pulumiType = args.type;
+    return filter(args.props) ? args.props : undefined;
+}
+
+/**
+ * StackValidationPolicy is a policy that validates a stack.
+ */
+export interface StackValidationPolicy extends Policy {
+    /**
+     * A callback function that validates if a stack violates a policy.
+     */
+    validateStack: StackValidation;
+}
+
+/**
+ * StackValidation is the callback signature for a `StackValidationPolicy`. A stack validation is passed
+ * `args` with more information about the stack and a `reportViolation` callback that can be used to
+ * report a policy violation. `reportViolation` can be called multiple times to report multiple violations
+ * against the stack. `reportViolation` must be passed a message about the violation, and an optional `urn`
+ * to a resource in the stack that's in violation of the policy. Not specifying a `urn` indicates the
+ * overall stack is in violation of the policy.
+ */
+export type StackValidation = (args: StackValidationArgs, reportViolation: ReportViolation) => Promise<void> | void;
+
+/**
+ * StackValidationArgs is the argument bag passed to a resource validation.
+ */
+export interface StackValidationArgs {
+    /**
+     * The resources in the stack.
+     */
+    resources: PolicyResource[];
+}
+
+/**
+ * PolicyResource represents a resource in the stack.
+ */
+export interface PolicyResource {
+    /**
+     * The type of the Resource.
+     */
+    type: string;
+
+    /**
+     * The outputs of the Resource.
+     */
+    props: Record<string, any>;
+
+    // TODO: Add support for the following:
+    //
+    // urn: string;
+    // name: string;
+    // opts: PolicyResourceOptions;
+}
+
+/**
+ * ReportViolation is the callback signature used to report policy violations.
+ */
+export type ReportViolation = (message: string, urn?: string) => void;

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -18,7 +18,7 @@ const analyzerrpc = require("@pulumi/pulumi/proto/analyzer_grpc_pb.js");
 const structproto = require("google-protobuf/google/protobuf/struct_pb.js");
 const plugproto = require("@pulumi/pulumi/proto/plugin_pb.js");
 
-import { EnforcementLevel, Policy, Tag } from "./policy";
+import { EnforcementLevel, Policies } from "./policy";
 
 export function asGrpcError(e: any, message?: string) {
     if (message === undefined || message === "") {
@@ -72,11 +72,6 @@ export interface Diagnostic {
     message: string;
 
     /**
-     * A keyword or term to associate with a policy, such as "cost" or "security."
-     */
-    tags?: Tag[];
-
-    /**
      * Indicates what to do on policy violation, e.g., block deployment but allow override with
      * proper permissions.
      */
@@ -90,7 +85,7 @@ export interface Diagnostic {
 
 // ------------------------------------------------------------------------------------------------
 
-export function makeAnalyzerInfo(policyPackName: string, policies: Policy[]): any {
+export function makeAnalyzerInfo(policyPackName: string, policies: Policies): any {
     const ai: any = new analyzerproto.AnalyzerInfo();
     ai.setName(policyPackName);
 
@@ -120,7 +115,6 @@ export function makeAnalyzeResponse(ds: Diagnostic[]) {
         diagnostic.setPolicypackversion(d.policyPackVersion);
         diagnostic.setDescription(d.description);
         diagnostic.setMessage(d.message);
-        diagnostic.setTagsList(d.tags);
         diagnostic.setEnforcementlevel(mapEnforcementLevel(d.enforcementLevel));
 
         diagnostics.push(diagnostic);

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -167,5 +167,17 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
 
 // Type guard used to determine if the `Policy` is a `ResourceValidationPolicy`.
 function isResourcePolicy(p: Policy): p is ResourceValidationPolicy {
-    return typeof (p as ResourceValidationPolicy).validateResource === "function";
+    const validation = (p as ResourceValidationPolicy).validateResource;
+    if (typeof validation === "function") {
+        return true;
+    }
+    if (Array.isArray(validation)) {
+        for (const v of validation) {
+            if (typeof v !== "function") {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
 }

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -20,7 +20,13 @@ const plugproto = require("@pulumi/pulumi/proto/plugin_pb.js");
 import { AssertionError } from "assert";
 
 import { deserializeProperties } from "./deserialize";
-import { EnforcementLevel, Policy, Tag } from "./policy";
+import {
+    Policies,
+    Policy,
+    ReportViolation,
+    ResourceValidationArgs,
+    ResourceValidationPolicy,
+} from "./policy";
 import {
     asGrpcError,
     Diagnostic,
@@ -41,7 +47,7 @@ import { version } from "./version";
 
 let serving = false;
 
-export function serve(policyPackName: string, policyPackVersion: string, policies: Policy[]): void {
+export function serve(policyPackName: string, policyPackVersion: string, policies: Policies): void {
     if (serving !== false) {
         throw Error("Only one policy gRPC server can run per process");
     }
@@ -68,7 +74,7 @@ export function serve(policyPackName: string, policyPackVersion: string, policie
 function makeGetAnalyzerInfoRpcFun(
     policyPackName: string,
     policyPackVersion: string,
-    policies: Policy[],
+    policies: Policies,
 ) {
     return async function(call: any, callback: any): Promise<void> {
         try {
@@ -90,7 +96,7 @@ async function getPluginInfoRpc(call: any, callback: any): Promise<void> {
 }
 
 // analyze is the RPC call that will analyze an individual resource, one at a time (i.e., check).
-function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, policies: Policy[]) {
+function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, policies: Policies) {
     return async function(call: any, callback: any): Promise<void> {
         // Prep to perform the analysis.
         const req = call.request;
@@ -99,21 +105,41 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
         const ds: Diagnostic[] = [];
         try {
             for (const p of policies) {
-                let policyRules = [];
-                if (Array.isArray(p.rules)) {
-                    policyRules = p.rules;
-                } else {
-                    policyRules = [p.rules];
+                if (!isResourcePolicy(p)) {
+                    continue;
                 }
 
-                for (const rule of policyRules) {
+                const reportViolation: ReportViolation = (message, urn) => {
+                    const { validateResource, name, ...diag } = p;
+
+                    ds.push({
+                        policyName: name,
+                        policyPackName,
+                        policyPackVersion,
+                        message: message,
+                        ...diag,
+                    });
+                };
+
+                const validations = Array.isArray(p.validateResource)
+                    ? p.validateResource
+                    : [p.validateResource];
+
+                for (const validation of validations) {
                     try {
                         const deserd = deserializeProperties(req.getProperties());
-                        rule(req.getType(), unknownCheckingProxy(deserd));
+                        const args: ResourceValidationArgs = {
+                            type: req.getType(),
+                            props: unknownCheckingProxy(deserd),
+                        };
+
+                        // Pass the result of the validate call to Promise.resolve.
+                        // If the value is a promise, that promise is returned; otherwise
+                        // the returned promise will be fulfilled with the value.
+                        await Promise.resolve(validation(args, reportViolation));
                     } catch (e) {
                         if (e instanceof UnknownValueError) {
-                            // `Diagnostic` is just an `AdmissionPolicy` without a `rule` field.
-                            const { rules, name, ...diag } = p;
+                            const { validateResource, name, ...diag } = p;
 
                             ds.push({
                                 policyName: name,
@@ -122,23 +148,6 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
                                 message: `can't run policy '${name}' during preview: ${e.message}`,
                                 ...diag,
                                 enforcementLevel: "advisory",
-                            });
-                        } else if (e instanceof AssertionError) {
-                            // `Diagnostic` is just an `AdmissionPolicy` without a `rule` field.
-                            const { rules, name, ...diag } = p;
-
-                            const [expect, op, actual] = [e.expected, e.operator, e.actual];
-                            const expectation = `observed value '${expect}' was expected to ${op} '${actual}'`;
-                            const message = e.generatedMessage
-                                ? `[${name}] ${diag.description}\n${expectation}`
-                                : `[${name}] ${diag.description}\n${e.message}`;
-
-                            ds.push({
-                                policyName: name,
-                                policyPackName,
-                                policyPackVersion,
-                                message: message,
-                                ...diag,
                             });
                         } else {
                             throw asGrpcError(e, `Error validating resource with policy ${p.name}`);
@@ -154,4 +163,9 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
         // Now marshal the results into a resulting diagnostics list, and invoke the callback to finish.
         callback(undefined, makeAnalyzeResponse(ds));
     };
+}
+
+// Type guard used to determine if the `Policy` is a `ResourceValidationPolicy`.
+function isResourcePolicy(p: Policy): p is ResourceValidationPolicy {
+    return typeof (p as ResourceValidationPolicy).validateResource === "function";
 }

--- a/sdk/nodejs/policy/tests/pb.spec.ts
+++ b/sdk/nodejs/policy/tests/pb.spec.ts
@@ -49,11 +49,7 @@ describe("makeAnalyzerInfo", () => {
                     name: "approved-amis-by-id",
                     description: "Instances should use approved AMIs",
                     enforcementLevel: "mandatory",
-                    rules: [
-                        () => {
-                            return;
-                        },
-                    ],
+                    validateResource: (args, reportViolation) => { return; },
                 },
             ]);
         });
@@ -66,11 +62,7 @@ describe("makeAnalyzerInfo", () => {
                     name: "approved-amis-by-id",
                     description: "Instances should use approved AMIs",
                     enforcementLevel: <any>"invalidEnforcementLevel",
-                    rules: [
-                        () => {
-                            return;
-                        },
-                    ],
+                    validateResource: (args, reportViolation) => { return; },
                 },
             ]);
         });
@@ -90,15 +82,6 @@ describe("makeAnalyzeResponse", () => {
                     policyPackVersion: "1",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
-                    enforcementLevel: "mandatory",
-                },
-                {
-                    policyName: "approved-amis-by-id",
-                    policyPackName: "awsSecRules",
-                    policyPackVersion: "1",
-                    description: "Instances should use approved AMIs",
-                    message: "Did not use approved AMI",
-                    tags: ["security"],
                     enforcementLevel: "mandatory",
                 },
             ]);

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,0 +1,191 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrationtests
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	ptesting "github.com/pulumi/pulumi/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func abortIfFailed(t *testing.T) {
+	if t.Failed() {
+		t.Fatal("Aborting test as a result of unrecoverable error.")
+	}
+}
+
+// policyTestScenario describes an iteration of the
+type policyTestScenario struct {
+	// WantErrors is the error message we expect to see in the command's output.
+	WantErrors []string
+}
+
+// runPolicyPackIntegrationTest creates a new Pulumi stack and then runs through
+// a sequence of test scenarios where a configuration value is set and then
+// the stack is updated or previewed, confirming the expected result.
+func runPolicyPackIntegrationTest(
+	t *testing.T, testDirName string,
+	initialConfig map[string]string, scenarios []policyTestScenario) {
+	t.Logf("Running Policy Pack Integration Test from directory %q", testDirName)
+
+	// Get the directory for the policy pack to run.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error getting working directory")
+	}
+	rootDir := path.Join(cwd, testDirName)
+
+	stackName := fmt.Sprintf("%s-%d", testDirName, time.Now().Unix()%100000)
+
+	// Copy the root directory to /tmp and run various operations within that directory.
+	e := ptesting.NewEnvironment(t)
+	defer func() {
+		if !t.Failed() {
+			e.DeleteEnvironment()
+		}
+	}()
+	e.ImportDirectory(rootDir)
+
+	// Change to the Policy Pack directory.
+	packDir := path.Join(e.RootPath, "policy-pack")
+	e.CWD = packDir
+
+	// Get dependencies.
+	e.RunCommand("yarn", "install")
+	abortIfFailed(t)
+
+	// Link @pulumi/policy.
+	e.RunCommand("yarn", "link", "@pulumi/policy")
+	abortIfFailed(t)
+
+	// Change to the Pulumi program directory.
+	programDir := path.Join(e.RootPath, "program")
+	e.CWD = programDir
+
+	// Create the stack.
+	e.RunCommand("pulumi", "login", "--local")
+	abortIfFailed(t)
+
+	e.RunCommand("pulumi", "stack", "init", stackName)
+	abortIfFailed(t)
+
+	// Get dependencies.
+	e.RunCommand("yarn", "install")
+	abortIfFailed(t)
+
+	// Initial configuration.
+	for k, v := range initialConfig {
+		e.RunCommand("pulumi", "config", "set", k, v)
+	}
+
+	// After this point, we want be sure to cleanup the stack, so we don't accidentally leak
+	// any cloud resources.
+	defer func() {
+		t.Log("Cleaning up Stack")
+		e.RunCommand("pulumi", "destroy", "--yes")
+		e.RunCommand("pulumi", "stack", "rm", "--yes")
+	}()
+
+	assert.True(t, len(scenarios) > 0, "no test scenarios provided")
+	for idx, scenario := range scenarios {
+		// Create a sub-test so go test will output data incrementally, which will let
+		// a CI system like Travis know not to kill the job if no output is sent after 10m.
+		// idx+1 to make it 1-indexed.
+		t.Run(fmt.Sprintf("Scenario_%d", idx+1), func(t *testing.T) {
+			e.T = t
+
+			e.RunCommand("pulumi", "config", "set", "scenario", fmt.Sprintf("%d", idx+1))
+
+			if len(scenario.WantErrors) == 0 {
+				t.Log("No errors are expected.")
+				e.RunCommand("pulumi", "up", "--policy-pack", packDir)
+			} else {
+				stdout, stderr := e.RunCommandExpectError("pulumi", "up", "--policy-pack", packDir)
+
+				for _, wantErr := range scenario.WantErrors {
+					inSTDOUT := strings.Contains(stdout, wantErr)
+					inSTDERR := strings.Contains(stderr, wantErr)
+
+					if !inSTDOUT && !inSTDERR {
+						t.Errorf("Did not find expected error %q", wantErr)
+					}
+				}
+
+				if t.Failed() {
+					t.Logf("Command output:\nSTDOUT:\n%v\n\nSTDERR:\n%v\n\n", stdout, stderr)
+				}
+			}
+		})
+	}
+
+	e.T = t
+	t.Log("Finished test scenarios.")
+	// Cleanup already registered via defer.
+}
+
+// Test basic resource validation.
+func TestValidateResource(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "validate_resource", nil, []policyTestScenario{
+		// Test scenario 1: no resources.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 2: no violations.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 3: violates the first policy.
+		{
+			WantErrors: []string{
+				"pulumi-nodejs:dynamic:Resource (a):",
+				"  mandatory: 'state' must not have the value 1.",
+			},
+		},
+		// Test scenario 4: violates the second policy.
+		{
+			WantErrors: []string{
+				"pulumi-nodejs:dynamic:Resource (b):",
+				"  mandatory: 'state' must not have the value 2.",
+			},
+		},
+		// Test scenario 5: violates the first validation function of the third policy.
+		{
+			WantErrors: []string{
+				"pulumi-nodejs:dynamic:Resource (c):",
+				"  mandatory: 'state' must not have the value 3.",
+			},
+		},
+		// Test scenario 6: violates the second validation function of the third policy.
+		{
+			WantErrors: []string{
+				"pulumi-nodejs:dynamic:Resource (d):",
+				"  mandatory: 'state' must not have the value 4.",
+			},
+		},
+		// Test scenario 7: violates the fourth policy.
+		{
+			WantErrors: []string{
+				"random:index:RandomUuid (random):",
+				"  mandatory: RandomUuid must not have an empty 'keepers'.",
+			},
+		},
+	})
+}

--- a/tests/integration/validate_resource/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/validate_resource/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+description: A Policy Pack for validating test resources.
+runtime: nodejs

--- a/tests/integration/validate_resource/policy-pack/index.ts
+++ b/tests/integration/validate_resource/policy-pack/index.ts
@@ -1,0 +1,67 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import { PolicyPack, validateTypedResource } from "@pulumi/policy";
+import * as random from "@pulumi/random";
+
+new PolicyPack("validate-resource-test-policy", {
+    policies: [
+        {
+            name: "dynamic-no-state-with-value-1",
+            description: "Prohibits setting state to 1 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                    if (args.props.state === 1) {
+                        reportViolation("'state' must not have the value 1.")
+                    }
+                }
+            },
+        },
+        // More than one policy.
+        {
+            name: "dynamic-no-state-with-value-2",
+            description: "Prohibits setting state to 2 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                    if (args.props.state === 2) {
+                        reportViolation("'state' must not have the value 2.")
+                    }
+                }
+            },
+        },
+        // Multiple validateResource callbacks.
+        {
+            name: "dynamic-no-state-with-value-3-or-4",
+            description: "Prohibits setting state to 3 or 4 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateResource: [
+                (args, reportViolation) => {
+                    if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                        if (args.props.state === 3) {
+                            reportViolation("'state' must not have the value 3.")
+                        }
+                    }
+                },
+                (args, reportViolation) => {
+                    if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                        if (args.props.state === 4) {
+                            reportViolation("'state' must not have the value 4.")
+                        }
+                    }
+                },
+            ],
+        },
+        // Strongly-typed.
+        {
+            name: "randomuuid-no-keepers",
+            description: "Prohibits creating a RandomUuid without any 'keepers'.",
+            enforcementLevel: "mandatory",
+            validateResource: validateTypedResource(random.RandomUuid.isInstance, (it, args, reportViolation) => {
+                if (!it.keepers || Object.keys(it.keepers).length === 0) {
+                    reportViolation("RandomUuid must not have an empty 'keepers'.")
+                }
+            }),
+        },
+    ],
+});

--- a/tests/integration/validate_resource/policy-pack/package.json
+++ b/tests/integration/validate_resource/policy-pack/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "aws-typescript",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/validate_resource/policy-pack/tsconfig.json
+++ b/tests/integration/validate_resource/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/validate_resource/program/Pulumi.yaml
+++ b/tests/integration/validate_resource/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: validate_resource
+runtime: nodejs
+description: A program that creates some dynamic resources for testing.

--- a/tests/integration/validate_resource/program/index.ts
+++ b/tests/integration/validate_resource/program/index.ts
@@ -1,0 +1,44 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import { Resource } from "./resource";
+
+const config = new pulumi.Config();
+const testScenario = config.getNumber("scenario");
+
+switch (testScenario) {
+    case 1:
+        // Don't create any resources.
+        break;
+
+    case 2:
+        // Create a resource that doesn't violate any policies.
+        const hello = new Resource("hello", { hello: "world" });
+        break;
+
+    case 3:
+        // Violates the first policy.
+        const a = new Resource("a", { state: 1 });
+        break;
+
+    case 4:
+        // Violates the second policy.
+        const b = new Resource("b", { state: 2 });
+        break;
+
+    case 5:
+        // Violates the first validation function of the third policy.
+        const c = new Resource("c", { state: 3 });
+        break;
+
+    case 6:
+        // Violates the second validation function of the third policy.
+        const d = new Resource("d", { state: 4 });
+        break;
+
+    case 7:
+        // Violates the fourth policy.
+        const r = new random.RandomUuid("random");
+        break;
+}

--- a/tests/integration/validate_resource/program/package.json
+++ b/tests/integration/validate_resource/program/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
+    }
+}

--- a/tests/integration/validate_resource/program/resource.ts
+++ b/tests/integration/validate_resource/program/resource.ts
@@ -1,0 +1,26 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: undefined,
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    public isInstance(o: any): o is Resource {
+        return o.__pulumiType === "pulumi-nodejs:dynamic:Resource";
+    }
+
+    constructor(name: string, props: pulumi.Inputs, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+    }
+}

--- a/tests/integration/validate_resource/program/tsconfig.json
+++ b/tests/integration/validate_resource/program/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "resource.ts"
+    ]
+}


### PR DESCRIPTION
Apologies for the long description.  This PR implements the latest API proposal, addressing some feedback [since we discussed earlier this week](https://docs.google.com/document/d/1b-8GKeL4zkXVn-BjiO-H0BDeY6hgg-lxioY3psDG1zs/edit#). Please read it over and take a look at the changes in this PR and the associated PR that updates the examples https://github.com/pulumi/examples/pull/441

Some changes since we discussed earlier this week:

 - This demonstrates a `validateTypedResource` helper for stronger typed resource checking, similar to the previous `typedRule` helper.

    Here's an example:

    ```typescript
    new PolicyPack("policy-pack-typescript", {
        policies: [{
            name: "s3-no-public-read",
            description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
            enforcementLevel: "mandatory",
            validateResource: validateTypedResource(aws.s3.Bucket.isInstance, (it, args, reportViolation) => {
                if (it.acl === "public-read" || it.acl === "public-read-write") {
                    reportViolation(
                        "You cannot set public-read or public-read-write on an S3 bucket. " +
                        "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");
                }
            }),
        }],
    });
    ```

 - I keep waffling on changing `EnforcementLevel`, `"advisory"`, and `"mandatory"` to `Severity`, `"warning"`, and `"error"`. I don't feel strongly about it, but was initially leaning towards the less verbose `Severity`. However, Cameron pointed out we might want to add a `"softMandatory"` or `"requiresApproval"` value in the future, which doesn't work as well with `Severity`, so I've left it `EnforcementLevel` for now. Still open to changing.

 - Originally, I specified the `Policy` as:

    ```typescript
    export interface Policy {
        name: string;
        description: string;
        enforcementLevel: EnforcementLevel;

        validateResource?: ResourceValidation;
        validateStack?: StackValidation;
    }
    ```

    Which would allow setting either `validateResource` or `validateStack` on a policy. However, [Cameron's feedback](https://docs.google.com/a/pulumi.com/document/d/1b-8GKeL4zkXVn-BjiO-H0BDeY6hgg-lxioY3psDG1zs/edit?disco=AAAADempQdU) was that we should not allow both.

    To address, I've separated these out as follows so that the compiler will enforce defining either a `validateResource` or `validatStack`:

    ```typescript
    export interface Policy {
        name: string;
        description: string;
        enforcementLevel: EnforcementLevel;
    }

    export interface ResourceValidationPolicy extends Policy {
        validateResource: ResourceValidation | ResourceValidation[];
    }

    export interface StackValidationPolicy extends Policy {
        validateStack: StackValidation;
    }

    export type Policies = (ResourceValidationPolicy | StackValidationPolicy)[];
    ```

    If the additional types add too much cognitive load, we could consider going back to the simpler design with two optional properties on the main `Policy` interface. We could also consider making it a runtime check to enforce only setting one of the two properties (if we felt strongly about enforcing this). Or, we could allow both to be set, but generally recommend setting one or the other.

 - You'll probably notice that I changed:

    ```typescript
    validateResource: ResourceValidation;
    ```

    to:

    ```typescript
    validateResource: ResourceValidation | ResourceValidation[];
    ```

    I know we discussed how it didn't make a lot of sense to have `rules` which accepted a single `rule` (despite using this pattern elsewhere like in AWSX), and how the assumption is that most polices will have a single rule. When updating the examples, I found it was just easier to be able to provide multiple validation functions to be called for certain policies that are checking similar things across multiple resource types (e.g. EC2 `Instance`, `LaunchConfiguration`, or `LaunchTemplate` are [using only approved AMIs](https://github.com/pulumi/examples/pull/441/files#diff-02168f5f7813feed7b3872ba18a781feR33)).

    ```typescript
    {
        name: name,
        description: "Instances should use approved AMIs.",
        enforcementLevel: "mandatory",
        validateResource: [
            validateTypedResource(aws.ec2.Instance.isInstance, (it, args, reportViolation) => {
                if (amis && !amis.has(it.ami)) {
                    reportViolation("EC2 Instances should use approved AMIs.");
                }
            }),
            validateTypedResource(aws.ec2.LaunchConfiguration.isInstance, (it, args, reportViolation) => {
                if (amis && !amis.has(it.imageId)) {
                    reportViolation("EC2 LaunchConfigurations should use approved AMIs.");
                }
            }),
            validateTypedResource(aws.ec2.LaunchTemplate.isInstance, (it, args, reportViolation) => {
                if (amis && it.imageId && !amis.has(it.imageId)) {
                    reportViolation("EC2 LaunchTemplates should use approved AMIs.");
                }
            }),
        ],
    };
    ```


    This is largely due to the way the `validateTypedResource` helper works to provide stronger typed resource objects to check since it only allows converting a single validation function into a strongly-typed resource. However, instead of making the property name plural (like with the previous `rules`), I've left it singular as the majority of policies will only have a single `validateResource` validation function -- but if it's simpler to implement a policy using multiple validation functions, the option is available.

    Though, we could go about strongly typing the resource in a different way which could obviate the need for multiple validation functions for such policies. More below.


 - The implementation of `ResourceValidationPolicy` has been hooked-up, but `StackValidationPolicy` has not yet. @chrsmith, want me to do it, now that your change in `pulumi/pulumi` has been merged?


 - [Here's an example](https://github.com/pulumi/examples/pull/441/files#diff-02168f5f7813feed7b3872ba18a781feR211) of a policy that is looking for potentially multiple violations, but something where you don't necessarily have to exit early when the first violation is found:

    ```typescript
        export function requireEbsEncryption(name: string, kmsKeyId?: string): ResourceValidationPolicy {
        return {
            name: name,
            description: "EBS volumes should be encrypted",
            enforcementLevel: "mandatory",
            validateResource: validateTypedResource(aws.ebs.Volume.isInstance, (it, args, reportViolation) => {
                if (!it.encrypted) {
                    reportViolation("EBS volumes should be encrypted.");
                }
                if (kmsKeyId !== undefined && it.kmsKeyId !== kmsKeyId) {
                    reportViolation(`EBS volumes should be encrypted with KMS ID '${kmsKeyId}'.`);
                }
            }),
        };
    }
    ```

## A different way to do stronger-typed resources

While the `validateTypedResource` approach to providing a strongly typed resource to program against works, it has two problems:

1. For policies that are looking for similar things over multiple resource types, it necessitates multiple validation functions (one per resource). It'd be nice if we could keep it a single validation function, and do the stronger typed filtering inside that.

2. The approach won't extend to the `validateStack` check, where you'll likely also want stronger-typed resources when looking at various resources in the stack.

One way to solve this would be to provide a helper like:

```typescript
export function asResource<TResource extends Resource>(
    isInstance: (o: any) => o is TResource,
    args: { type: string, props: Record<string, any> },
): q.ResolvedResource<TResource> | undefined {
    args.props.__pulumiType = args.type;
    return isInstance(args.props) ? args.props : undefined;
}
```

Basically, if we can convert the resource, we will return it as the stronger typed `q.ResolvedResource<TResource>`, otherwise `undefined`.

Using it in a `validateResource` function would look like:

```typescript
new PolicyPack("policy-pack-typescript", {
    policies: [{
        name: "s3-no-public-read",
        description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
        enforcementLevel: "mandatory",
        validateResource: (args, reportViolation) => {
            const it = asResource(aws.s3.Bucket.isInstance, args);
            if (it && (it.acl === "public-read" || it.acl === "public-read-write")) {
                reportViolation(
                    "You cannot set public-read or public-read-write on an S3 bucket. " +
                    "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");
            }
        },
    }],
});
```

And you could have multiple calls to `asResource` inside the single validation function, to cast to as many resource types as you'd like. Though, it's a bit more verbose and cumbersome than the `validateTypedResource` helper.

But the same `asResource` helper function could be used inside `validateStack` to get stronger typing for the resources there.

What do folks think?

Part of #87