### PR TITLE
Hook up `StackValidationPolicy`

### DIFF
--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-policy",
     "dependencies": {
-        "@pulumi/pulumi": "0.17.23",
+        "@pulumi/pulumi": "1.4.1",
         "google-protobuf": "^3.5.0",
         "grpc": "^1.20.2",
         "protobufjs": "^6.8.6"

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -23,9 +23,12 @@ import { deserializeProperties } from "./deserialize";
 import {
     Policies,
     Policy,
+    PolicyResource,
     ReportViolation,
     ResourceValidationArgs,
     ResourceValidationPolicy,
+    StackValidationArgs,
+    StackValidationPolicy,
 } from "./policy";
 import {
     asGrpcError,
@@ -58,6 +61,7 @@ export function serve(policyPackName: string, policyPackVersion: string, policie
     const server = new grpc.Server();
     server.addService(analyzerrpc.AnalyzerService, {
         analyze: makeAnalyzeRpcFun(policyPackName, policyPackVersion, policies),
+        analyzeStack: makeAnalyzeStackRpcFun(policyPackName, policyPackVersion, policies),
         getAnalyzerInfo: makeGetAnalyzerInfoRpcFun(policyPackName, policyPackVersion, policies),
         getPluginInfo: getPluginInfoRpc,
     });
@@ -70,7 +74,6 @@ export function serve(policyPackName: string, policyPackVersion: string, policie
     console.log(port);
 }
 
-// analyze is the RPC call that will analyze an individual resource, one at a time (i.e., check).
 function makeGetAnalyzerInfoRpcFun(
     policyPackName: string,
     policyPackVersion: string,
@@ -95,7 +98,8 @@ async function getPluginInfoRpc(call: any, callback: any): Promise<void> {
     }
 }
 
-// analyze is the RPC call that will analyze an individual resource, one at a time (i.e., check).
+// analyze is the RPC call that will analyze an individual resource, one at a time, called with the
+// "inputs" to the resource, before it is updated.
 function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, policies: Policies) {
     return async function(call: any, callback: any): Promise<void> {
         // Prep to perform the analysis.
@@ -165,6 +169,77 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
     };
 }
 
+// analyzeStack is the RPC call that will analyze all resources within a stack, at the end of a successful
+// preview or update. The provided resources are the "outputs", after any mutations have taken place.
+function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersion: string, policies: Policies) {
+    return async function(call: any, callback: any): Promise<void> {
+        // Prep to perform the analysis.
+        const req = call.request;
+
+        // Run the analysis for every analyzer in the global list, tracking any diagnostics.
+        const ds: Diagnostic[] = [];
+        try {
+            for (const p of policies) {
+                if (!isStackPolicy(p)) {
+                    continue;
+                }
+
+                const reportViolation: ReportViolation = (message, urn) => {
+                    const { validateStack, name, ...diag } = p;
+
+                    ds.push({
+                        policyName: name,
+                        policyPackName,
+                        policyPackVersion,
+                        message: message,
+                        ...diag,
+                    });
+                };
+
+                try {
+                    const resources: PolicyResource[] = [];
+                    for (const r of req.getResourcesList()) {
+                        resources.push({
+                            type: r.getType(),
+                            props: r.getProperties().toJavaScript(),
+                        });
+                    }
+
+                    const args: StackValidationArgs = {
+                        resources: resources,
+                    };
+
+                    // Pass the result of the validate call to Promise.resolve.
+                    // If the value is a promise, that promise is returned; otherwise
+                    // the returned promise will be fulfilled with the value.
+                    await Promise.resolve(p.validateStack(args, reportViolation));
+                } catch (e) {
+                    if (e instanceof UnknownValueError) {
+                        const { validateStack, name, ...diag } = p;
+
+                        ds.push({
+                            policyName: name,
+                            policyPackName,
+                            policyPackVersion,
+                            message: `can't run policy '${name}' during preview: ${e.message}`,
+                            ...diag,
+                            enforcementLevel: "advisory",
+                        });
+                    } else {
+                        throw asGrpcError(e, `Error validating stack with policy ${p.name}`);
+                    }
+                }
+            }
+        } catch (err) {
+            callback(err, undefined);
+            return;
+        }
+
+        // Now marshal the results into a resulting diagnostics list, and invoke the callback to finish.
+        callback(undefined, makeAnalyzeResponse(ds));
+    };
+}
+
 // Type guard used to determine if the `Policy` is a `ResourceValidationPolicy`.
 function isResourcePolicy(p: Policy): p is ResourceValidationPolicy {
     const validation = (p as ResourceValidationPolicy).validateResource;
@@ -180,4 +255,9 @@ function isResourcePolicy(p: Policy): p is ResourceValidationPolicy {
         return true;
     }
     return false;
+}
+
+// Type guard used to determine if the `Policy` is a `StackValidationPolicy`.
+function isStackPolicy(p: Policy): p is StackValidationPolicy {
+    return typeof (p as StackValidationPolicy).validateStack === "function";
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -189,3 +189,29 @@ func TestValidateResource(t *testing.T) {
 		},
 	})
 }
+
+// Test basic stack validation.
+func TestValidateStack(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "validate_stack", nil, []policyTestScenario{
+		// Test scenario 1: no resources.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 2: no violations.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 3: violates the first policy.
+		{
+			WantErrors: []string{
+				"  mandatory: 'state' must not have the value 1.",
+			},
+		},
+		// Test scenario 4: violates the second policy.
+		{
+			WantErrors: []string{
+				"  mandatory: 'state' must not have the value 2.",
+			},
+		},
+	})
+}

--- a/tests/integration/validate_stack/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/validate_stack/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+description: A Policy Pack for validating a test stack.
+runtime: nodejs

--- a/tests/integration/validate_stack/policy-pack/index.ts
+++ b/tests/integration/validate_stack/policy-pack/index.ts
@@ -1,0 +1,60 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import { PolicyPack } from "@pulumi/policy";
+
+new PolicyPack("validate-stack-test-policy", {
+    policies: [
+        // // Temporary policy for debugging.
+        // {
+        //     name: "temporary-debug-policy",
+        //     description: "Temp debug policy that reports violations for each resource to see their values.",
+        //     enforcementLevel: "mandatory",
+        //     validateStack: (args, reportViolation) => {
+        //         for (const r of args.resources) {
+        //             reportViolation(`${r.type} with props ${Object.keys(r.props).join(",")} failure`);
+        //         }
+        //     },
+        // },
+        {
+            name: "dynamic-no-state-with-value-1",
+            description: "Prohibits setting state to 1 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateStack: (args, reportViolation) => {
+                for (const r of args.resources) {
+                    // FIXME: We don't have any outputs during previews and aren't merging
+                    // inputs, so just skip for now if we have an empty props.
+                    if (Object.keys(r.props).length === 0) {
+                        continue;
+                    }
+
+                    if (r.type === "pulumi-nodejs:dynamic:Resource") {
+                        if (r.props.state === 1) {
+                            reportViolation("'state' must not have the value 1.")
+                        }
+                    }
+                }
+            },
+        },
+        // More than one policy.
+        {
+            name: "dynamic-no-state-with-value-2",
+            description: "Prohibits setting state to 2 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateStack: (args, reportViolation) => {
+                for (const r of args.resources) {
+                    // FIXME: We don't have any outputs during previews and aren't merging
+                    // inputs, so just skip for now if we have an empty props.
+                    if (Object.keys(r.props).length === 0) {
+                        continue;
+                    }
+
+                    if (r.type === "pulumi-nodejs:dynamic:Resource") {
+                        if (r.props.state === 2) {
+                            reportViolation("'state' must not have the value 2.")
+                        }
+                    }
+                }
+            },
+        },
+    ],
+});

--- a/tests/integration/validate_stack/policy-pack/package.json
+++ b/tests/integration/validate_stack/policy-pack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "validate-stack-policy",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/validate_stack/policy-pack/tsconfig.json
+++ b/tests/integration/validate_stack/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/validate_stack/program/Pulumi.yaml
+++ b/tests/integration/validate_stack/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: validate_stack
+runtime: nodejs
+description: A program that creates some dynamic resources for testing.

--- a/tests/integration/validate_stack/program/index.ts
+++ b/tests/integration/validate_stack/program/index.ts
@@ -1,0 +1,28 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import { Resource } from "./resource";
+
+const config = new pulumi.Config();
+const testScenario = config.getNumber("scenario");
+
+switch (testScenario) {
+    case 1:
+        // Don't create any resources.
+        break;
+
+    case 2:
+        // Create a resource that doesn't violate any policies.
+        const hello = new Resource("hello", { hello: "world" });
+        break;
+
+    case 3:
+        // Violates the first policy.
+        const a = new Resource("a", { state: 1 });
+        break;
+
+    case 4:
+        // Violates the second policy.
+        const b = new Resource("b", { state: 2 });
+        break;
+}

--- a/tests/integration/validate_stack/program/package.json
+++ b/tests/integration/validate_stack/program/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0"
+    }
+}

--- a/tests/integration/validate_stack/program/resource.ts
+++ b/tests/integration/validate_stack/program/resource.ts
@@ -1,0 +1,26 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: { ...inputs },
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    public isInstance(o: any): o is Resource {
+        return o.__pulumiType === "pulumi-nodejs:dynamic:Resource";
+    }
+
+    constructor(name: string, props: pulumi.Inputs, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+    }
+}

--- a/tests/integration/validate_stack/program/tsconfig.json
+++ b/tests/integration/validate_stack/program/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "resource.ts"
+    ]
+}


### PR DESCRIPTION
This hooks up the changes in https://github.com/pulumi/pulumi/pull/3366 to the new `validateStack` API.

I ran into two issues while working on this that we should discuss before merging this:

1. During previews, the outputs are always empty. It took me a while to figure this out. I thought I'd screwed up the gRPC calls, but as soon as I added `--skip-preview` to the `pulumi up` commands in the integration tests I started seeing the outputs.

    I think this is going to be confusing for folks writing policies. At the very least, should we consider providing an `isPreview` property on the args, that could be checked to see if the policy is being run during a preview vs. update? Or only run stack validation policies during updates (I don't think we want to do that, since there is a class of policies you might still want to fail during previews, such as basic cost analysis based on the type, or only allowing a certain number of resources)?

  2. We're [currently _only_ passing the resources outputs](https://github.com/pulumi/pulumi/blob/a9db935ccc96b8d35c172c7ca31ebc4387738d0a/pkg/resource/deploy/plan_executor.go#L277-L279). We really should be sending both the outputs _and_ inputs (merging the two like we do [here](https://github.com/pulumi/pulumi/blob/29049ecaf31ebe9f66870de415e7cda636ebc325/sdk/nodejs/runtime/resource.ts#L470-L475)). Either that or have separate `inputs` and `outputs` properties rather than a single `props`.

cc @chrsmith, @ekrengel

Fixes #105