### PR TITLE
Don't used `Resolved` for strongly-typed resource policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
           name: "s3-no-public-read",
           description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
           enforcementLevel: "mandatory",
-          validateResource: validateTypedResource(aws.s3.Bucket.isInstance, (it, args, reportViolation) => {
-              if (it.acl === "public-read" || it.acl === "public-read-write") {
+          validateResource: validateTypedResource(aws.s3.Bucket, (bucket, args, reportViolation) => {
+              if (bucket.acl === "public-read" || bucket.acl === "public-read-write") {
                   reportViolation(
                       "You cannot set public-read or public-read-write on an S3 bucket. " +
                       "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -145,22 +145,6 @@ export function validateTypedResource<TResource extends Resource, TArgs>(
 }
 
 /**
- * A helper function that returns `props` as a strongly-typed resolved resource based
- * on the specified `type` when `filter` returns true, otherwise `undefined` is returned.
- * @param typeFilter A type guard used to determine if the args are an instance of the resource.
- * @param args Argument bag for specifying the `type` and `props`.
- */
-export function asTypedResource<TResource extends Resource>(
-    typeFilter: (o: any) => o is TResource,
-    args: { type: string, props: Record<string, any> },
-): q.ResolvedResource<TResource> | undefined {
-    if (typeFilter({ __pulumiType: args.type }) !== true) {
-        return undefined;
-    }
-    return args.props as q.ResolvedResource<TResource>;
-}
-
-/**
  * StackValidationPolicy is a policy that validates a stack.
  */
 export interface StackValidationPolicy extends Policy {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -187,6 +187,10 @@ func TestValidateResource(t *testing.T) {
 				"  mandatory: RandomUuid must not have an empty 'keepers'.",
 			},
 		},
+		// Test scenario 8: no violations.
+		{
+			WantErrors: nil,
+		},
 	})
 }
 

--- a/tests/integration/validate_resource/policy-pack/index.ts
+++ b/tests/integration/validate_resource/policy-pack/index.ts
@@ -57,7 +57,7 @@ new PolicyPack("validate-resource-test-policy", {
             name: "randomuuid-no-keepers",
             description: "Prohibits creating a RandomUuid without any 'keepers'.",
             enforcementLevel: "mandatory",
-            validateResource: validateTypedResource(random.RandomUuid.isInstance, (it, args, reportViolation) => {
+            validateResource: validateTypedResource(random.RandomUuid, (it, args, reportViolation) => {
                 if (!it.keepers || Object.keys(it.keepers).length === 0) {
                     reportViolation("RandomUuid must not have an empty 'keepers'.")
                 }

--- a/tests/integration/validate_resource/program/index.ts
+++ b/tests/integration/validate_resource/program/index.ts
@@ -39,6 +39,15 @@ switch (testScenario) {
 
     case 7:
         // Violates the fourth policy.
-        const r = new random.RandomUuid("random");
+        const r1 = new random.RandomUuid("random");
+        break;
+
+    case 8:
+        // Doesn't violate the fourth policy.
+        const r2 = new random.RandomUuid("random", {
+            keepers: {
+                foo: "bar",
+            },
+        });
         break;
 }


### PR DESCRIPTION
We currently use `pulumi.queryable.ResolvedResource<T>` in the strongly-typed `validateTypedResource` helper, but this represents the "output" shape of the object when it really should be the "input" shape, since these policies are receiving the resource inputs.

This PR modifies `validateTypedResource` so that it provides the "input" shape of the resource, i.e. the args type used when creating the resource.

Instead of passing a `typeFilter` type guard, the class itself is passed. From this, we can infer the resource's args type, based on its constructor parameters, which represents the "input" shape we want. We use [`Unwrap<TArgs>`](https://github.com/pulumi/pulumi/blob/1a6897ba262c0668340fa5e62a26f89cc538ec41/sdk/nodejs/output.ts#L460-L490) so that the properties are typed as `T` instead of `Input<T>`.

Before:

```typescript
// Passing the `isInstance` function.
validateResource: validateTypedResource(aws.s3.Bucket.isInstance, (bucket, args, reportViolation) => {
    // Here `bucket` is the "resolved" output shape, e.g. `aws.s3.Bucket` with all properties typed as `T` instead of `Output<T>`.
});
```

After:

```typescript
// Passing the class itself.
validateResource: validateTypedResource(aws.s3.Bucket, (bucket, args, reportViolation) => {
    // Here `bucket` is the "unwrapped" input shape, e.g. `aws.s3.BucketArgs` with all properties typed as `T` instead of `Input<T>`.
}):
```

Updated examples here: https://github.com/pulumi/examples/pull/455

Fixes #116