### PR TITLE
Update README for Pulumi 1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This beta feature is also available via the Pulumi Console. To get this feature 
 ### Verify your version of the Pulumi CLI
 
 ```sh
-pulumi version # should be > v1.4.1
+pulumi version # should be v1.5.2 or later
 ```
 
 If you need to upgrade your Pulumi CLI, you can find instructions [here](https://www.pulumi.com/docs/get-started/install/).
@@ -45,10 +45,10 @@ If you need to upgrade your Pulumi CLI, you can find instructions [here](https:/
     mkdir policypack && cd policypack
     ```
 
-1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_DEBUG_COMMANDS=true` as an environment variable or simply pre-append it to your commands as shown. (Note: Pulumi 1.4.1 or later is required to use `pulumi policy new` command.)
+1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_EXPERIMENTAL=true` as an environment variable or simply pre-append it to your commands as shown.
 
     ```sh
-    PULUMI_DEBUG_COMMANDS=true pulumi policy new aws-typescript
+    PULUMI_EXPERIMENTAL=true pulumi policy new aws-typescript
     ```
 
 1. Tweak the Policy Pack in the `index.ts` file as desired. The existing policy in the template (which is annotated below) mandates that an AWS S3 bucket not have public read or write permissions enabled. Each Policy must have a unique name, an enforcement level, and a validation function. Here we use `validateTypedResource` that allows us to validate S3 Bucket resources.
@@ -96,13 +96,13 @@ Policy Packs can be tested on a user's local workstation to facilitate rapid dev
     In the Pulumi project's directory run:
 
     ```sh
-    PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack <path-to-policy-pack-directory>
+    PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack <path-to-policy-pack-directory>
     ```
 
     If the stack is in compliance, we expect the output to simply tell us which Policy Packs were run.
 
     ```sh
-    PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack policy-pack-typescript
+    PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack policy-pack-typescript
     Previewing update (dev):
 
         Type                 Name          Plan
@@ -127,7 +127,7 @@ Policy Packs can be tested on a user's local workstation to facilitate rapid dev
 1. We then run the `pulumi preview` command again and this time get an error message indicating we failed the preview because of a policy violation.
 
     ```sh
-    PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack ~/policy-pack-typescript
+    PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack ~/policy-pack-typescript
     Previewing update (dev):
 
         Type                 Name          Plan       Info


### PR DESCRIPTION
Let's just recommend using 1.5.2. And while `PULUMI_DEBUG_COMMANDS` still works, let's recommend the preferred `PULUMI_EXPERIMENTAL` be used instead.