### PR TITLE
Revert back to PULUMI_DEBUG_COMMANDS for PaC commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ If you need to upgrade your Pulumi CLI, you can find instructions [here](https:/
     mkdir policypack && cd policypack
     ```
 
-1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_EXPERIMENTAL=true` as an environment variable or simply pre-append it to your commands as shown.
+1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_DEBUG_COMMANDS=true` as an environment variable or simply pre-append it to your commands as shown.
 
     ```sh
-    PULUMI_EXPERIMENTAL=true pulumi policy new aws-typescript
+    PULUMI_DEBUG_COMMANDS=true pulumi policy new aws-typescript
     ```
 
 1. Tweak the Policy Pack in the `index.ts` file as desired. The existing policy in the template (which is annotated below) mandates that an AWS S3 bucket not have public read or write permissions enabled. Each Policy must have a unique name, an enforcement level, and a validation function. Here we use `validateTypedResource` that allows us to validate S3 Bucket resources.
@@ -96,13 +96,13 @@ Policy Packs can be tested on a user's local workstation to facilitate rapid dev
     In the Pulumi project's directory run:
 
     ```sh
-    PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack <path-to-policy-pack-directory>
+    PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack <path-to-policy-pack-directory>
     ```
 
     If the stack is in compliance, we expect the output to simply tell us which Policy Packs were run.
 
     ```sh
-    PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack policy-pack-typescript
+    PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack policy-pack-typescript
     Previewing update (dev):
 
         Type                 Name          Plan
@@ -127,7 +127,7 @@ Policy Packs can be tested on a user's local workstation to facilitate rapid dev
 1. We then run the `pulumi preview` command again and this time get an error message indicating we failed the preview because of a policy violation.
 
     ```sh
-    PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack ~/policy-pack-typescript
+    PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack ~/policy-pack-typescript
     Previewing update (dev):
 
         Type                 Name          Plan       Info


### PR DESCRIPTION
We missed updating the `--policy-pack` flag to work with `PULUMI_EXPERIMENTAL`, so just go back to showing `PULUMI_DEBUG_COMMANDS` for now.