### PR TITLE
Expose resource `urn` and `name` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## HEAD (Unreleased)
 
+## 0.3.0 (2019-11-26)
+
+- Add `"disabled"` to `EnforcementLevel` to disable policies
+  (https://github.com/pulumi/pulumi-policy/pull/156).
+- Add resource `urn` and `name` properties along with support for reporting the URN associated with
+  a stack validation policy violation (https://github.com/pulumi/pulumi-policy/pull/151).
+
 ## 0.2.0 (2019-11-13)
 
 ### Improvements

--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-policy",
     "dependencies": {
-        "@pulumi/pulumi": "1.4.1",
+        "@pulumi/pulumi": "^1.6.1",
         "google-protobuf": "^3.5.0",
         "grpc": "^1.20.2",
         "protobufjs": "^6.8.6"

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -138,19 +138,27 @@ export type ResourceValidation = (args: ResourceValidationArgs, reportViolation:
  */
 export interface ResourceValidationArgs {
     /**
-     * The type of the Resource.
+     * The type of the resource.
      */
     type: string;
 
     /**
-     * The properties of the Resource.
+     * The properties of the resource.
      */
     props: Record<string, any>;
 
+    /**
+     * The URN of the resource.
+     */
+    urn: string;
+
+    /**
+     * The name of the resource.
+     */
+    name: string;
+
     // TODO: Add support for the following:
     //
-    // urn: string;
-    // name: string;
     // opts: PolicyResourceOptions;
 }
 
@@ -214,19 +222,27 @@ export interface StackValidationArgs {
  */
 export interface PolicyResource {
     /**
-     * The type of the Resource.
+     * The type of the resource.
      */
     type: string;
 
     /**
-     * The outputs of the Resource.
+     * The outputs of the resource.
      */
     props: Record<string, any>;
 
+    /**
+     * The URN of the resource.
+     */
+    urn: string;
+
+    /**
+     * The name of the resource.
+     */
+    name: string;
+
     // TODO: Add support for the following:
     //
-    // urn: string;
-    // name: string;
     // opts: PolicyResourceOptions;
 }
 

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -78,6 +78,11 @@ export interface Diagnostic {
      * proper permissions.
      */
     enforcementLevel: EnforcementLevel;
+
+    /**
+     * The URN of the resource that has the policy violation.
+     */
+    urn?: string;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -122,6 +127,7 @@ export function makeAnalyzeResponse(ds: Diagnostic[]) {
         diagnostic.setDescription(d.description);
         diagnostic.setMessage(d.message);
         diagnostic.setEnforcementlevel(mapEnforcementLevel(d.enforcementLevel));
+        diagnostic.setUrn(d.urn);
 
         diagnostics.push(diagnostic);
     }

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -135,6 +135,7 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
                         policyPackName,
                         policyPackVersion,
                         message: `[${name}] ${diag.description}\n${message}`,
+                        urn: urn,
                         ...diag,
                     });
                 };
@@ -149,6 +150,8 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
                         const args: ResourceValidationArgs = {
                             type: req.getType(),
                             props: unknownCheckingProxy(deserd),
+                            urn: req.getUrn(),
+                            name: req.getName(),
                         };
 
                         // Pass the result of the validate call to Promise.resolve.
@@ -206,6 +209,7 @@ function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersion: strin
                         policyPackName,
                         policyPackVersion,
                         message: `[${name}] ${diag.description}\n${message}`,
+                        urn: urn,
                         ...diag,
                     });
                 };
@@ -216,6 +220,8 @@ function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersion: strin
                         resources.push({
                             type: r.getType(),
                             props: r.getProperties().toJavaScript(),
+                            urn: r.getUrn(),
+                            name: r.getName(),
                         });
                     }
 

--- a/sdk/nodejs/policy/tests/pb.spec.ts
+++ b/sdk/nodejs/policy/tests/pb.spec.ts
@@ -97,6 +97,19 @@ describe("makeAnalyzeResponse", () => {
                 },
             ]);
         });
+        assert.doesNotThrow(() => {
+            makeAnalyzeResponse([
+                {
+                    policyName: "approved-amis-by-id",
+                    policyPackName: "awsSecRules",
+                    policyPackVersion: "1",
+                    description: "Instances should use approved AMIs",
+                    message: "Did not use approved AMI",
+                    enforcementLevel: "mandatory",
+                    urn: "foo",
+                },
+            ]);
+        });
     });
 
     it("throws for disabled or invalid enforcementLevel", () => {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -220,6 +220,14 @@ func TestValidateResource(t *testing.T) {
 		{
 			WantErrors: nil,
 		},
+		// Test scenario 9: violates the fifth policy.
+		{
+			WantErrors: []string{
+				"pulumi-nodejs:dynamic:Resource (e):",
+				"  mandatory: [dynamic-no-state-with-value-5] Prohibits setting state to 5 on dynamic resources.",
+				"  'state' must not have the value 5.",
+			},
+		},
 	})
 }
 
@@ -264,6 +272,14 @@ func TestValidateStack(t *testing.T) {
 			WantErrors: []string{
 				"  mandatory: [dynamic-no-state-with-value-2] Prohibits setting state to 2 on dynamic resources.",
 				"  'state' must not have the value 2.",
+			},
+		},
+		// Test scenario 5: violates the third policy.
+		{
+			WantErrors: []string{
+				"pulumi-nodejs:dynamic:Resource (c):",
+				"  mandatory: [dynamic-no-state-with-value-3] Prohibits setting state to 3 on dynamic resources.",
+				"  'state' must not have the value 3.",
 			},
 		},
 	})

--- a/tests/integration/validate_resource/policy-pack/index.ts
+++ b/tests/integration/validate_resource/policy-pack/index.ts
@@ -63,5 +63,18 @@ new PolicyPack("validate-resource-test-policy", {
                 }
             }),
         },
+        // Specifying a URN explicitly has no affect for validateResource.
+        {
+            name: "dynamic-no-state-with-value-5",
+            description: "Prohibits setting state to 5 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                if (args.type === "pulumi-nodejs:dynamic:Resource") {
+                    if (args.props.state === 5) {
+                        reportViolation("'state' must not have the value 5.", "some-urn")
+                    }
+                }
+            },
+        },
     ],
 });

--- a/tests/integration/validate_resource/program/index.ts
+++ b/tests/integration/validate_resource/program/index.ts
@@ -50,4 +50,9 @@ switch (testScenario) {
             },
         });
         break;
+
+    case 9:
+        // Violates the fifth policy.
+        const e = new Resource("e", { state: 5 });
+        break;
 }

--- a/tests/integration/validate_stack/policy-pack/index.ts
+++ b/tests/integration/validate_stack/policy-pack/index.ts
@@ -56,5 +56,26 @@ new PolicyPack("validate-stack-test-policy", {
                 }
             },
         },
+        // Policy that specifies the URN of the resource violating the policy.
+        {
+            name: "dynamic-no-state-with-value-3",
+            description: "Prohibits setting state to 3 on dynamic resources.",
+            enforcementLevel: "mandatory",
+            validateStack: (args, reportViolation) => {
+                for (const r of args.resources) {
+                    // FIXME: We don't have any outputs during previews and aren't merging
+                    // inputs, so just skip for now if we have an empty props.
+                    if (Object.keys(r.props).length === 0) {
+                        continue;
+                    }
+
+                    if (r.type === "pulumi-nodejs:dynamic:Resource") {
+                        if (r.props.state === 3) {
+                            reportViolation("'state' must not have the value 3.", r.urn);
+                        }
+                    }
+                }
+            },
+        },
     ],
 });

--- a/tests/integration/validate_stack/program/index.ts
+++ b/tests/integration/validate_stack/program/index.ts
@@ -25,4 +25,9 @@ switch (testScenario) {
         // Violates the second policy.
         const b = new Resource("b", { state: 2 });
         break;
+
+    case 5:
+        // Violates the third policy.
+        const c = new Resource("c", { state: 3 });
+        break;
 }


### PR DESCRIPTION
And hook up support for reporting the URN associated with a violation.

This depends on https://github.com/pulumi/pulumi/pull/3554