### PR TITLE
Add "disabled" value to EnforcementLevel

### DIFF
--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -47,7 +47,7 @@ export class PolicyPack {
 /**
  * Indicates the impact of a policy violation.
  */
-export type EnforcementLevel = "advisory" | "mandatory";
+export type EnforcementLevel = "advisory" | "mandatory" | "disabled";
 
 /**
  * A policy function that returns true if a resource definition violates some policy (e.g., "no

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -130,7 +130,17 @@ export function mapEnforcementLevel(el: EnforcementLevel) {
             return analyzerproto.EnforcementLevel.ADVISORY;
         case "mandatory":
             return analyzerproto.EnforcementLevel.MANDATORY;
+        // Disabled is treated as if the policy was not defined, so the value should not escape over GRPC.
+        case "disabled":
+            throw new Error("'disabled' should not escape the GRPC boundary");
         default:
-            throw Error(`Unknown enforcement level type '${el}'`);
+            throw new UnknownEnforcementLevelError(el);
+    }
+}
+
+// Ensures all possible values are covered in the switch.
+class UnknownEnforcementLevelError extends Error {
+    constructor(el: never) {
+        super(`Unknown enforcement level type '${el}'`);
     }
 }

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -83,7 +83,8 @@ function makeGetAnalyzerInfoRpcFun(
 ) {
     return async function(call: any, callback: any): Promise<void> {
         try {
-            callback(undefined, makeAnalyzerInfo(policyPackName, policies));
+            const enabledPolicies = (policies || []).filter(p => p.enforcementLevel !== "disabled");
+            callback(undefined, makeAnalyzerInfo(policyPackName, enabledPolicies));
         } catch (e) {
             callback(asGrpcError(e), undefined);
         }
@@ -111,7 +112,7 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
         const ds: Diagnostic[] = [];
         try {
             for (const p of policies) {
-                if (!isResourcePolicy(p)) {
+                if (p.enforcementLevel === "disabled" || !isResourcePolicy(p)) {
                     continue;
                 }
 
@@ -182,7 +183,7 @@ function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersion: strin
         const ds: Diagnostic[] = [];
         try {
             for (const p of policies) {
-                if (!isStackPolicy(p)) {
+                if (p.enforcementLevel === "disabled" || !isStackPolicy(p)) {
                     continue;
                 }
 

--- a/sdk/nodejs/policy/tests/pb.spec.ts
+++ b/sdk/nodejs/policy/tests/pb.spec.ts
@@ -36,6 +36,7 @@ describe("mapEnforcementLevel", () => {
             mapEnforcementLevel("mandatory"),
             analyzerproto.EnforcementLevel.MANDATORY,
         );
+        assert.throws(() => mapEnforcementLevel("disabled"));
         assert.throws(() => mapEnforcementLevel(<any>"invalidEnforcementLevel"));
     });
 });
@@ -55,7 +56,17 @@ describe("makeAnalyzerInfo", () => {
         });
     });
 
-    it("throws for invalid enforcementLevel", () => {
+    it("throws for disabled or invalid enforcementLevel", () => {
+        assert.throws(() => {
+            makeAnalyzerInfo("testRules", [
+                {
+                    name: "approved-amis-by-id",
+                    description: "Instances should use approved AMIs",
+                    enforcementLevel: "disabled",
+                    validateResource: (args, reportViolation) => { return; },
+                },
+            ]);
+        });
         assert.throws(() => {
             makeAnalyzerInfo("testRules", [
                 {
@@ -88,7 +99,19 @@ describe("makeAnalyzeResponse", () => {
         });
     });
 
-    it("throws for invalid enforcementLevel", () => {
+    it("throws for disabled or invalid enforcementLevel", () => {
+        assert.throws(() => {
+            makeAnalyzeResponse([
+                {
+                    policyName: "approved-amis-by-id",
+                    policyPackName: "awsSecRules",
+                    policyPackVersion: "1",
+                    description: "Instances should use approved AMIs",
+                    message: "Did not use approved AMI",
+                    enforcementLevel: "disabled",
+                },
+            ]);
+        });
         assert.throws(() => {
             makeAnalyzeResponse([
                 {


### PR DESCRIPTION
This allows disabling policies. A disabled policy is treated as if it wasn't defined, which means it will be excluded from analyzer info and when analyzing resources and the stack (i.e. the CLI and service don't need to know about `"disabled"`).