### PR TITLE
Wrap TArgs in NonNullable before Unwrap

### DIFF
--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -128,7 +128,7 @@ export interface ResourceValidationArgs {
 export function validateTypedResource<TResource extends Resource, TArgs>(
     resourceClass: { new(name: string, args: TArgs, ...rest: any[]): TResource },
     validate: (
-        props: NonNullable<Unwrap<TArgs>>,
+        props: Unwrap<NonNullable<TArgs>>,
         args: ResourceValidationArgs,
         reportViolation: ReportViolation) => Promise<void> | void,
 ): ResourceValidation {
@@ -140,7 +140,7 @@ export function validateTypedResource<TResource extends Resource, TArgs>(
         if (isInstance({ __pulumiType: args.type }) !== true) {
             return;
         }
-        validate(args.props as NonNullable<Unwrap<TArgs>>, args, reportViolation);
+        validate(args.props as Unwrap<NonNullable<TArgs>>, args, reportViolation);
     };
 }
 


### PR DESCRIPTION
Minor suggestion from Cyrus. While this doesn't really matter in practice, it technically makes more sense to make `TArgs` [non-nullable](https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullablet) first before [unwrapping it](https://github.com/pulumi/pulumi/blob/669b80af96d7d390c7af4aec6d5144bf76c8ad2b/sdk/nodejs/output.ts#L571-L601), rather than the other way around.