### PR TITLE
Improvements for API docs

### DIFF
--- a/sdk/nodejs/policy/deserialize.ts
+++ b/sdk/nodejs/policy/deserialize.ts
@@ -22,6 +22,7 @@ import {
 
 /**
  * deserializeProperties fetches the raw outputs and deserializes them from a gRPC call result.
+ * @internal
  */
 export function deserializeProperties(outputsStruct: any): any {
     const props: any = {};

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -20,6 +20,7 @@ const plugproto = require("@pulumi/pulumi/proto/plugin_pb.js");
 
 import { EnforcementLevel, Policies } from "./policy";
 
+/** @internal */
 export function asGrpcError(e: any, message?: string) {
     if (message === undefined || message === "") {
         message = "";
@@ -48,6 +49,7 @@ export function asGrpcError(e: any, message?: string) {
 /**
  * Diagnostic information and metadata that can be used to emit helpful error messages when a policy
  * is violated.
+ * @internal
  */
 export interface Diagnostic {
     /** Name of the policy that was violated. */
@@ -85,6 +87,7 @@ export interface Diagnostic {
 
 // ------------------------------------------------------------------------------------------------
 
+/** @internal */
 export function makeAnalyzerInfo(policyPackName: string, policies: Policies): any {
     const ai: any = new analyzerproto.AnalyzerInfo();
     ai.setName(policyPackName);
@@ -103,7 +106,10 @@ export function makeAnalyzerInfo(policyPackName: string, policies: Policies): an
     return ai;
 }
 
-// makeAnalyzeResponse creates a protobuf encoding the given list of diagnostics.
+/**
+ * makeAnalyzeResponse creates a protobuf encoding the given list of diagnostics.
+ * @internal
+ */
 export function makeAnalyzeResponse(ds: Diagnostic[]) {
     const resp = new analyzerproto.AnalyzeResponse();
 
@@ -124,6 +130,7 @@ export function makeAnalyzeResponse(ds: Diagnostic[]) {
     return resp;
 }
 
+/** @internal */
 export function mapEnforcementLevel(el: EnforcementLevel) {
     switch (el) {
         case "advisory":

--- a/sdk/nodejs/policy/proxy.ts
+++ b/sdk/nodejs/policy/proxy.ts
@@ -20,6 +20,7 @@
  * `pulumi preview`, and only filled in during the update.
  *
  * @param toProxy resource inputs to create a proxy for
+ * @internal
  */
 export function unknownCheckingProxy<T>(toProxy: any): any {
     return proxyHelper(toProxy, []);
@@ -28,8 +29,8 @@ export function unknownCheckingProxy<T>(toProxy: any): any {
 /**
  * `proxyHelper` is a helper for the `unknownCheckingProxy` function.
  * @param toProxy resource inputs to create a proxy for
- * @param propsAcc accumulates the property path, e.g., for `resc.foo.bar`, this would be `["foo",
- * "bar"]`
+ * @param propsAcc accumulates the property path, e.g., for `resc.foo.bar`, this would be `["foo","bar"]`
+ * @internal
  */
 function proxyHelper<T>(toProxy: any, propsAcc: (keyof T)[]): any {
     if (!(toProxy instanceof Object)) {
@@ -53,6 +54,7 @@ function proxyHelper<T>(toProxy: any, propsAcc: (keyof T)[]): any {
  * unknown. For example, during preview, some resource fields (such as an allocated IP address)
  * can't be known until the update is executed; an attempt to access such a field will result in
  * this exception.
+ * @internal
  */
 export class UnknownValueError<T> extends Error {
     public readonly unknownTypeSentinel: string;
@@ -103,28 +105,35 @@ function unknownToString(o: string): string {
 // unknownBooleanValue is a sentinel indicating that a boolean property's value is not known,
 // because it depends on a computation with values whose values themselves are not yet known (e.g.,
 // dependent upon an output property).
+/** @internal */
 export const unknownBooleanValue = "1c4a061d-8072-4f0a-a4cb-0ff528b18fe7";
 // unknownNumberValue is a sentinel indicating that a number property's value is not known, because
 // it depends on a computation with values whose values themselves are not yet known (e.g.,
 // dependent upon an output property).
+/** @internal */
 export const unknownNumberValue = "3eeb2bf0-c639-47a8-9e75-3b44932eb421";
 // unknownStringValue is a sentinel indicating that a string property's value is not known, because
 // it depends on a computation with values whose values themselves are not yet known (e.g.,
 // dependent upon an output property).
+/** @internal */
 export const unknownStringValue = "04da6b54-80e4-46f7-96ec-b56ff0331ba9";
 // unknownArrayValue is a sentinel indicating that an array property's value is not known, because
 // it depends on a computation with values whose values themselves are not yet known (e.g.,
 // dependent upon an output property).
+/** @internal */
 export const unknownArrayValue = "6a19a0b0-7e62-4c92-b797-7f8e31da9cc2";
 // unknownAssetValue is a sentinel indicating that an asset property's value is not known, because
 // it depends on a computation with values whose values themselves are not yet known (e.g.,
 // dependent upon an output property).
+/** @internal */
 export const unknownAssetValue = "030794c1-ac77-496b-92df-f27374a8bd58";
 // unknownArchiveValue is a sentinel indicating that an archive property's value is not known,
 // because it depends on a computation with values whose values themselves are not yet known (e.g.,
 // dependent upon an output property).
+/** @internal */
 export const unknownArchiveValue = "e48ece36-62e2-4504-bad9-02848725956a";
 // unknownObjectValue is a sentinel indicating that an archive property's value is not known,
 // because it depends on a computation with values whose values themselves are not yet known (e.g.,
 // dependent upon an output property).
+/** @internal */
 export const unknownObjectValue = "dd056dcd-154b-4c76-9bd3-c8f88648b5ff";

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -49,6 +49,17 @@ import * as process from "process";
 // Name of the policy pack currently being served, if applicable.
 let servingPolicyPack: string | undefined = undefined;
 
+/**
+  * Starts the gRPC server to communicate with the Pulumi CLI client for analyzing resources.
+  *
+  * Only one gRPC server can be running at a time, and the port the server is running on will
+  * be written to STDOUT.
+  *
+  * @param policyPackName Friendly name of the policy pack.
+  * @param policyPackVersion Version of the policy pack SDK used.
+  * @param policies The policies to be served.
+  * @internal
+  */
 export function serve(policyPackName: string, policyPackVersion: string, policies: Policies): void {
     if (servingPolicyPack) {
         // We only support running one gRPC instance at a time. (Since the Pulumi CLI is looking for a single

--- a/sdk/nodejs/policy/tsconfig.json
+++ b/sdk/nodejs/policy/tsconfig.json
@@ -16,15 +16,16 @@
         "strictNullChecks": true,
     },
     "files": [
+        "deserialize.ts",
         "index.ts",
-        "server.ts",
-        "version.ts",
+        "policy.ts",
         "protoutil.ts",
         "proxy.ts",
+        "server.ts",
+        "version.ts",
 
         "tests/deserialize.spec.ts",
         "tests/pb.spec.ts",
         "tests/proxy.spec.ts"
     ]
 }
-

--- a/sdk/nodejs/policy/version.ts
+++ b/sdk/nodejs/policy/version.ts
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/** @internal */
 export const version = "${VERSION}";


### PR DESCRIPTION
We were missing some files in tsconfig.json, which was causing the main APIs we want to document in `policy.ts` from showing up in the generated docs. Some "internal" things were also being included in the generated docs, so I added `@internal` to all of them, which prevents them from showing up in the declaration (`*.d.ts`) files and docs.

I also added some examples to our doc comments. Really just the same example in a couple places. Could definitely flesh this out with more examples, an example for stack validation, etc., but it's a start.

I also copied over Chris's comments improvements from his PR.