### PR TITLE
Build new docs in CI on new releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ensure::
 publish_packages:
 	$(call STEP_MESSAGE)
 	./scripts/publish_packages.sh
+	$$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh ${PROJECT_NAME}
 
 .PHONY: check_clean_worktree
 check_clean_worktree:


### PR DESCRIPTION
This will automatically open a PR in the docs repo when we release a new version. I patterned this off of https://github.com/pulumi/pulumi-aws/pull/733 and added the required `PULUMI_BOT_GITHUB_API_TOKEN` env variable in Travis.

Fixes #164