### PR TITLE
Test Config/getProject/getStack/isDryRun in policy packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## HEAD (Unreleased)
 
+### Improvements
+
+- Add support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs
+  via upgraded dependency on `@pulumi/pulumi` v1.8.0 (requires v1.8.0 of the Pulumi SDK).
+
 ## 0.3.0 (2019-11-26)
 
 ### Improvements

--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-policy",
     "dependencies": {
-        "@pulumi/pulumi": "^1.6.1",
+        "@pulumi/pulumi": "^1.8.0",
         "google-protobuf": "^3.5.0",
         "grpc": "^1.20.2",
         "protobufjs": "^6.8.6"

--- a/tests/integration/runtime_data/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/runtime_data/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+description: A Policy Pack to test that runtime data (Config, getStack, getProject, and isDryRun) is available to Policy Packs.
+runtime: nodejs

--- a/tests/integration/runtime_data/policy-pack/index.ts
+++ b/tests/integration/runtime_data/policy-pack/index.ts
@@ -1,0 +1,60 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as assert from "assert";
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import { PolicyPack, PolicyResource } from "@pulumi/policy";
+
+new PolicyPack("runtime-data-policy", {
+    policies: [
+        {
+            name: "runtime-data-resource-validation",
+            description: "Verifies runtime data during resource validation.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                verifyData(args);
+            },
+        },
+        {
+            name: "runtime-data-stack-validation",
+            description: "Verifies runtime data during stack validation.",
+            enforcementLevel: "mandatory",
+            validateStack: (args, reportViolation) => {
+                for (const r of args.resources) {
+                    verifyData(r);
+                }
+            },
+        },
+    ],
+});
+
+function verifyData(r: PolicyResource) {
+    if (r.type !== "pulumi-nodejs:dynamic:Resource") {
+        return;
+    }
+
+    // Verify isDryRun().
+    assert.strictEqual(pulumi.runtime.isDryRun(), r.props.isDryRun,
+        "'isDryRun()' not the expected value (via resource prop).");
+
+    // Verify getProject().
+    assert.ok(process.env.PULUMI_TEST_PROJECT, "'PULUMI_TEST_PROJECT' not set.");
+    assert.strictEqual(pulumi.getProject(), process.env.PULUMI_TEST_PROJECT, "'getProject()' not the expected value.");
+    assert.strictEqual(pulumi.getProject(), r.props.getProject, "'getProject()' not the expected value.");
+
+    // Verify getStack().
+    assert.ok(process.env.PULUMI_TEST_STACK, "'PULUMI_TEST_STACK' not set.")
+    assert.strictEqual(pulumi.getStack(), process.env.PULUMI_TEST_STACK,
+        "'getStack()' not the expected value (via env var).");
+    assert.strictEqual(pulumi.getStack(), r.props.getStack,
+        "'getStack()' not the expected value (via resource prop).");
+
+    // Verify Config.
+    assert.deepStrictEqual(pulumi.runtime.allConfig(), r.props.allConfig,
+        "'allConfig()' not the expected value (via resource prop).")
+    const config = new pulumi.Config();
+    const value = config.require("aConfigValue");
+    assert.strictEqual(value, "this value is a value", "'aConfigValue' not the expected value.");
+    assert.strictEqual(aws.config.region, "us-west-2", "'aws.config.region' not the expected value.");
+}

--- a/tests/integration/runtime_data/policy-pack/package.json
+++ b/tests/integration/runtime_data/policy-pack/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "aws-typescript",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/aws": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/runtime_data/policy-pack/tsconfig.json
+++ b/tests/integration/runtime_data/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/runtime_data/program/Pulumi.yaml
+++ b/tests/integration/runtime_data/program/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: runtime_data
+runtime: nodejs
+description: >
+    A test program that creates a dynamic resource that passes along runtime data (as inputs & outputs) that the Policy
+    Pack will use to confirm it sees the same runtime data.

--- a/tests/integration/runtime_data/program/index.ts
+++ b/tests/integration/runtime_data/program/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+import { Resource } from "./resource";
+
+// Create a dynamic resource that passes along runtime data in its inputs and outputs.
+// The policy pack will confirm it sees the same data.
+const hello = new Resource("Hello", {
+    allConfig: pulumi.runtime.allConfig(),
+    getProject: pulumi.getProject(),
+    getStack: pulumi.getStack(),
+    isDryRun: pulumi.runtime.isDryRun(),
+});

--- a/tests/integration/runtime_data/program/package.json
+++ b/tests/integration/runtime_data/program/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0"
+    }
+}

--- a/tests/integration/runtime_data/program/resource.ts
+++ b/tests/integration/runtime_data/program/resource.ts
@@ -1,0 +1,33 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: inputs, // propagate inputs to outputs.
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    public isInstance(o: any): o is Resource {
+        return o.__pulumiType === "pulumi-nodejs:dynamic:Resource";
+    }
+
+    constructor(name: string, args: ResourceArgs, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, args, opts);
+    }
+}
+
+export interface ResourceArgs {
+    allConfig: {[key: string]: string};
+    getProject: string;
+    getStack: string;
+    isDryRun: boolean;
+}

--- a/tests/integration/runtime_data/program/tsconfig.json
+++ b/tests/integration/runtime_data/program/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "resource.ts"
+    ]
+}


### PR DESCRIPTION
Depends on https://github.com/pulumi/pulumi/pull/3612. The tests will fail until we have a new release of the CLI and `@pulumi/pulumi`.