### PR TITLE
Expose resource options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### Improvements
 
 - Add support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs
-  via upgraded dependency on `@pulumi/pulumi` v1.8.0 (requires v1.8.0 of the Pulumi SDK).
+  via upgraded dependency on `@pulumi/pulumi` v1.8.0 (requires v1.8.0 or later of the Pulumi SDK) (https://github.com/pulumi/pulumi-policy/pull/169).
+
+- Expose resource options (https://github.com/pulumi/pulumi-policy/pull/172).
 
 ## 0.3.0 (2019-11-26)
 

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -157,9 +157,68 @@ export interface ResourceValidationArgs {
      */
     name: string;
 
-    // TODO: Add support for the following:
-    //
-    // opts: PolicyResourceOptions;
+    /**
+     * The options of the resource.
+     */
+    opts: PolicyResourceOptions;
+}
+
+/**
+ * PolicyResourceOptions is the bag of settings that control a resource's behavior.
+ */
+export interface PolicyResourceOptions {
+    /**
+     * An optional parent resource to which this resource belongs.
+     */
+    parent?: string;
+
+    /**
+     * When set to true, protect ensures this resource cannot be deleted.
+     */
+    protect: boolean;
+
+    /**
+     * Dependencies of this resource.
+     */
+    dependencies: string[];
+
+    /**
+     * The provider to use for this resource.
+     */
+    provider: string;
+
+    /**
+     * Additional URNs that should be aliased to this resource.
+     */
+    aliases: string[];
+
+    /**
+     * An optional customTimeouts configuration block.
+     */
+    customTimeouts?: PolicyCustomTimeouts;
+
+    /**
+     * Outputs that should always be treated as secrets.
+     */
+    additionalSecretOutputs: string[];
+}
+
+/**
+ * Optional custom timeout options.
+ */
+export interface PolicyCustomTimeouts {
+    /**
+     * The optional create timeout in seconds.
+     */
+    create?: number;
+    /**
+     * The optional update timeout in seconds.
+     */
+    update?: number;
+    /**
+     * The optional delete timeout in seconds.
+     */
+    delete?: number;
 }
 
 /**
@@ -241,9 +300,10 @@ export interface PolicyResource {
      */
     name: string;
 
-    // TODO: Add support for the following:
-    //
-    // opts: PolicyResourceOptions;
+    /**
+     * The options of the resource.
+     */
+    opts: PolicyResourceOptions;
 }
 
 /**

--- a/sdk/nodejs/tslint.json
+++ b/sdk/nodejs/tslint.json
@@ -15,7 +15,7 @@
         "eofline": true,
         "file-header": [
             true,
-            "Copyright 2016-2019, Pulumi Corporation."
+            "Copyright 2016-20\\d\\d, Pulumi Corporation."
         ],
         "forin": true,
         "indent": [

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -297,3 +297,13 @@ func TestRuntimeData(t *testing.T) {
 		"aws:region":   "us-west-2",
 	}, []policyTestScenario{{WantErrors: nil}})
 }
+
+// Test resource options.
+func TestResourceOptions(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "resource_options", NodeJS, nil, []policyTestScenario{
+		// Test scenario 1: test resource options.
+		{WantErrors: nil},
+		// Test scenario 2: prepare for destroying the stack (unprotect protected resources).
+		{WantErrors: nil},
+	})
+}

--- a/tests/integration/resource_options/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/resource_options/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+description: A Policy Pack for validating resource options.
+runtime: nodejs

--- a/tests/integration/resource_options/policy-pack/index.ts
+++ b/tests/integration/resource_options/policy-pack/index.ts
@@ -1,0 +1,214 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import { deepStrictEqual, ok, strictEqual } from "assert";
+
+import * as pulumi from "@pulumi/pulumi";
+import { PolicyPack, PolicyResource, PolicyResourceOptions } from "@pulumi/policy";
+
+new PolicyPack("resource-options-test-policy", {
+    policies: [
+        {
+            name: "validate-resource",
+            description: "Validates resource options during `validateResource`.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                validate(args);
+            },
+        },
+        {
+            name: "validate-stack",
+            description: "Validates resource options during `validateStack`.",
+            enforcementLevel: "mandatory",
+            validateStack: (args, reportViolation) => {
+                for (const r of args.resources) {
+                    validate(r);
+                }
+            },
+        },
+    ],
+});
+
+function validate(r: PolicyResource) {
+    const config = new pulumi.Config();
+    const testScenario = config.requireNumber("scenario");
+
+    // We only validate during the first test scenario. The subsequent test scenario is only
+    // used to unprotect protected resources in preparation for destroying the stack.
+    if (testScenario !== 1) {
+        return;
+    }
+
+    switch (r.type) {
+        case "pulumi:pulumi:Stack":
+        case "pulumi:providers:pulumi-nodejs":
+            assertOptions(r.opts, {
+                protect: false,
+                dependencies: [],
+                provider: "",
+                aliases: [],
+                additionalSecretOutputs: [],
+            }, /*providerExactMatch*/ true);
+            break;
+
+        case "pulumi-nodejs:dynamic:Resource":
+            validateDynamicResource(r);
+            break;
+
+        case "random:index/randomUuid:RandomUuid":
+            assertOptions(r.opts, {
+                parent: getStackURN(),
+                protect: false,
+                dependencies: [],
+                provider: getURN("pulumi:providers:random", "custom-random-provider"),
+                aliases: [],
+                additionalSecretOutputs: [],
+            });
+            break;
+    }
+}
+
+function validateDynamicResource(r: PolicyResource) {
+    const defaultOptions: PolicyResourceOptions = {
+        parent: getStackURN(),
+        protect: false,
+        dependencies: [],
+        provider: getURN("pulumi:providers:pulumi-nodejs", "default"),
+        aliases: [],
+        additionalSecretOutputs: [],
+    };
+
+    switch (r.name) {
+        case "empty":
+        case "parent":
+        case "a":
+            assertOptions(r.opts, defaultOptions);
+            break;
+
+        case "child":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, {
+                parent: getURN("pulumi-nodejs:dynamic:Resource", "parent"),
+            }));
+            break;
+
+        case "protect":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, { protect: true}));
+            break;
+
+        case "b":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, {
+                dependencies: [getURN("pulumi-nodejs:dynamic:Resource", "a")],
+            }));
+            break;
+
+        case "aliased":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, {
+                aliases: [getURN("pulumi-nodejs:dynamic:Resource", "old-name-for-aliased")],
+            }));
+            break;
+
+        case "timeouts":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, {
+                customTimeouts: {
+                    create: 60,
+                    update: 120,
+                    delete: 180,
+                },
+            }));
+            break;
+
+        case "timeouts-create":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, {
+                customTimeouts: {
+                    create: 240,
+                },
+            }));
+            break;
+
+        case "timeouts-update":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, {
+                customTimeouts: {
+                    update: 300,
+                },
+            }));
+            break;
+
+        case "timeouts-delete":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, {
+                customTimeouts: {
+                    delete: 360,
+                },
+            }));
+            break;
+
+        case "secrets":
+            assertOptions(r.opts, Object.assign({}, defaultOptions, {
+                additionalSecretOutputs: ["foo"],
+            }));
+            break;
+    }
+}
+
+/**
+ * Asserts that the `actual` options are strictly equal to the `expected` options.
+ * @param actual the actual resource options.
+ * @param expected the expected resource options.
+ * @param providerExactMatch `true` for a strict equality check of the `provider` property,
+ *     otherwise verifies `actual.provider` starts with `expected.provider` (as the actual
+ *     provider may have a UUID appended).
+ */
+function assertOptions(actual: PolicyResourceOptions, expected: PolicyResourceOptions, providerExactMatch: boolean = false) {
+    assert(strictEqual, actual, expected, "parent");
+    assert(strictEqual, actual, expected, "protect");
+    assert(deepStrictEqual, actual, expected, "dependencies");
+    assert(deepStrictEqual, actual, expected, "aliases");
+    assert(deepStrictEqual, actual, expected, "customTimeouts");
+    assert(deepStrictEqual, actual, expected, "additionalSecretOutputs");
+
+    const action = providerExactMatch ? strictEqual : startsWith;
+    assert(action, actual, expected, "provider");
+}
+
+/**
+ * Creates a URN of the root stack resource.
+ */
+function getStackURN(): string {
+    return getURN("pulumi:pulumi:Stack", `${pulumi.getProject()}-${pulumi.getStack()}`);
+}
+
+/**
+ * Creates a URN from the given `type` and `name`.
+ * @param type the resource type.
+ * @param name the resource name.
+ */
+function getURN(type: string, name: string): string {
+    return `urn:pulumi:${pulumi.getStack()}::${pulumi.getProject()}::${type}::${name}`;
+}
+
+/**
+ * Asserts that `actual` is truthy and starts with `expected`.
+ * @param actual the actual value.
+ * @param expected the expected value.
+ * @param message the assertion message.
+ */
+function startsWith(actual: string, expected: string, message: string): void {
+    ok(actual && actual.startsWith(expected), message);
+}
+
+/**
+ * Calls `action`, passing the specified `property` of `actual` and `expected`.
+ * @param action the assertion action to perform.
+ * @param actual the actual resource options.
+ * @param expected the expected resource options.
+ * @param property the property of the resource options to check.
+ */
+function assert<K extends keyof PolicyResourceOptions>(
+    action: (actual: PolicyResourceOptions[K], expected: PolicyResourceOptions[K], message: string) => void,
+    actual: PolicyResourceOptions,
+    expected: PolicyResourceOptions,
+    property: K,
+): void {
+    const act = actual[property];
+    const exp = expected[property];
+    const msg = `'${property}' isn't the expected value.\n\n  Actual: '${act}'.\nExpected: '${exp}'.`;
+    action(act, exp, msg);
+}

--- a/tests/integration/resource_options/policy-pack/package.json
+++ b/tests/integration/resource_options/policy-pack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "aws-typescript",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/resource_options/policy-pack/tsconfig.json
+++ b/tests/integration/resource_options/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/resource_options/program/Pulumi.yaml
+++ b/tests/integration/resource_options/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: resource_options
+runtime: nodejs
+description: A program that creates some dynamic resources for testing resource options.

--- a/tests/integration/resource_options/program/index.ts
+++ b/tests/integration/resource_options/program/index.ts
@@ -1,0 +1,70 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import { Resource } from "./resource";
+
+const config = new pulumi.Config();
+const testScenario = config.requireNumber("scenario");
+
+// Create a resource that doesn't have any explicit options set.
+const empty = new Resource("empty");
+
+// Create resources with a parent/child relationship.
+const parent = new Resource("parent");
+const child = new Resource("child", {
+    parent: parent,
+});
+
+// Create a protected resource.
+const protect = new Resource("protect", {
+    // Only set `protect` during the first test scenario when the actual tests are run.
+    // Set it to `false` on any other test scenario in preparation for destroying the stack.
+    protect: testScenario === 1,
+});
+
+// Create resources with a dependency relationship.
+const a = new Resource("a");
+const b = new Resource("b", {
+    dependsOn: a,
+});
+
+// Create a resource with an alias to an old name.
+const aliased = new Resource("aliased", {
+    aliases: [{ name: "old-name-for-aliased" }],
+});
+
+// Create resources with custom timeouts.
+const timeouts = new Resource("timeouts", {
+    customTimeouts: {
+        create: "1m",
+        update: "2m",
+        delete: "3m",
+    },
+});
+const timeoutsCreate = new Resource("timeouts-create", {
+    customTimeouts: {
+        create: "4m",
+    },
+});
+const timeoutsUpdate = new Resource("timeouts-update", {
+    customTimeouts: {
+        update: "5m",
+    },
+});
+const timeoutsDelete = new Resource("timeouts-delete", {
+    customTimeouts: {
+        delete: "6m",
+    },
+});
+
+// Create a resource with additional secret outputs.
+const secrets = new Resource("secrets", {
+    additionalSecretOutputs: ["foo"],
+});
+
+// Create a custom random provider and use it when creating a RandomUuid resource.
+const randomProvider = new random.Provider("custom-random-provider");
+const uuid = new random.RandomUuid("uuid", {}, {
+    provider: randomProvider,
+});

--- a/tests/integration/resource_options/program/package.json
+++ b/tests/integration/resource_options/program/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
+    }
+}

--- a/tests/integration/resource_options/program/resource.ts
+++ b/tests/integration/resource_options/program/resource.ts
@@ -1,0 +1,22 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: {},
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    constructor(name: string, opts?: pulumi.CustomResourceOptions) {
+        super(Provider.instance, name, {}, opts);
+    }
+}

--- a/tests/integration/resource_options/program/tsconfig.json
+++ b/tests/integration/resource_options/program/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "resource.ts"
+    ]
+}


### PR DESCRIPTION
Exposes resource options to policies.

This depends on https://github.com/pulumi/pulumi/pull/3720 (CI will fail until we have a new CLI release with those changes).

Here's a summary of resource options that we could potentially expose to policies:

```typescript
export interface ResourceOptions {
    id?: Input<ID>; // An optional existing ID to load, rather than create.
    parent?: Resource; // An optional parent resource to which this resource belongs.
    dependsOn?: Input<Input<Resource>[]> | Input<Resource>; // An optional additional explicit dependencies on other resources.
    protect?: boolean; // When set to true, protect ensures this resource cannot be deleted.
    ignoreChanges?: string[]; // Ignore changes to any of the specified properties.
    version?: string; // An optional version, corresponding to the version of the provider plugin that should be used when operating on this resource. This version overrides the version information inferred from the current package and should rarely be used.
    aliases?: Input<URN | Alias>[]; // An optional list of aliases to treat this resource as matching.
    provider?: ProviderResource; // An optional provider to use for this resource's CRUD operations.
    customTimeouts?: CustomTimeouts; // An optional customTimeouts configuration block.
    transformations?: ResourceTransformation[]; // Optional list of transformations to apply to this resource during construction.
}

export interface CustomTimeouts {
    create?: string; // The optional create timeout represented as a string e.g. 5m, 40s, 1d.
    update?: string; // The optional update timeout represented as a string e.g. 5m, 40s, 1d.
    delete?: string; // The optional delete timeout represented as a string e.g. 5m, 40s, 1d.
}

export interface CustomResourceOptions extends ResourceOptions {
    deleteBeforeReplace?: boolean; // When set to true, deleteBeforeReplace indicates that this resource should be deleted before its replacement is created when replacement is necessary.
    additionalSecretOutputs?: string[]; // The names of outputs for this resource that should be treated as secrets. This augments the list that the resource provider and pulumi engine already determine based on inputs to your resource. It can be used to mark certain ouputs as a secrets on a per resource basis.
    import?: ID; // When provided with a resource ID, import indicates that this resource's provider should import its state from the cloud resource with the given ID. The inputs to the resource's constructor must align with the resource's current state. Once a resource has been imported, the import property must be removed from the resource's options.
}

export interface ComponentResourceOptions extends ResourceOptions {
    providers?: Record<string, ProviderResource> | ProviderResource[]; // An optional set of providers to use for child resources. Either keyed by package name (e.g. "aws"), or just provided as an array.  In the latter case, the package name will be retrieved from the provider itself. In the case of a single provider, the options can be simplified to just pass along `provider: theProvider`. Note: do not provide both [provider] and [providers];
}
```

Here's how these are projected to policies. Please see my inline comments/questions:

```typescript
export interface PolicyResourceOptions {
    // Parent URN. For `validateStack` we could consider exposing this as `PolicyResource` instead
    // of as a string (URN) to make it more usable since we have all the resources available.
    // But I don't think we can for `validateResource` since we won't have data on all the
    // resources at this point.
    // For `validateStack`, we could also consider providing a helpful `children: PolicyResources[]` property
    // (or `getChildren` function) to make it easier for folks to inspect a resource's children without having
    // to traverse the resources and build-up the children array manually.
    parent?: string;

    protect: boolean;

    // URNs. Again, for `validateStack`, should we expose this as `PolicyResource[]` to make it easier to use
    // Or is it better to have a consistent signature with `validateResource`.
    dependencies: string[];

    // This could be an empty string for the stack resource and provider resources.
    // I implemented this before the holidays, but I am now wondering if we should make the
    // signature optional, e.g. `provider?: string`, instead of returning an empty string.
    // Any preference?
    provider: string;

    aliases: string[]; // URNs.
    customTimeouts?: PolicyCustomTimeouts;
    additionalSecretOutputs: string[];
}

// I explored making the timeout properties strings to match our Node.js SDK (e.g. "5m"),
// but I think it'll be much easier to inspect these in policies as numbers (of seconds)
// rather than as strings. These are just numbers inside the engine, so if we were to
// expose them as strings on the policy side, we'd have to normalize the string value,
// i.e. if someone wrote "1m" or "60s" in the Pulumi program, we'd have to pick one
// canonical form to expose from the policy SDK. It won't be super clear to policy authors
// which form they should be using inside their policies (i.e. should authors be looking for
// the string form that was specified in the Pulumi program or the normalized form?). Also,
// other language SDKs don't even expose these as strings but rather as idiomatic types for
// the language, such as `TimeSpan` in our .NET SDK.
export interface PolicyCustomTimeouts {
    create?: number;
    update?: number;
    delete?: number;
}
```

I chose not to expose the following properties for now:

```typescript
// I don't think it makes sense to expose this. When this is specified in a Pulumi program,
// the resource's state is read from the resource monitor instead of the resource being registered,
// and its state isn't part of the stack's state.
id?: Input<ID>; // An optional existing ID to load, rather than create.

// We don't have this information readily available for `validateStack`.
ignoreChanges?: string[]; // Ignore changes to any of the specified properties.

// This wasn't readily available, but I can investigate whether it's possible to easily expose this
// if there is a good scenario for inspecting it in policies. For now, I've left it out.
version?: string; // An optional version, corresponding to the version of the provider plugin that should be used when operating on this resource.

// This is purely something that happens inside the language SDKs and isn't available in a way that could
// be exposed in policies.
transformations?: ResourceTransformation[]; // Optional list of transformations to apply to this resource during construction.

// We don't have this information readily available for `validateStack`.
deleteBeforeReplace?: boolean; // When set to true, deleteBeforeReplace indicates that this resource should be deleted before its replacement is created when replacement is necessary.

// It's unclear to me how this would be used from policies. We can tell it's an import for `validateResource`,
// but would need to investigate how to expose for `validateStack`.
import?: ID; // When provided with a resource ID, import indicates that this resource's provider should import its state from the cloud resource with the given ID.
```

Fixes #110