### PR TITLE
Provide easier type checking for `validateStack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs
   via upgraded dependency on `@pulumi/pulumi` v1.8.0 (requires v1.8.0 of the Pulumi SDK).
 
+- Provide easier type checking for `validateStack` (https://github.com/pulumi/pulumi-policy/pull/173).
+
 ## 0.3.0 (2019-11-26)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@
 - Add support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs
   via upgraded dependency on `@pulumi/pulumi` v1.8.0 (requires v1.8.0 of the Pulumi SDK).
 
-- Provide easier type checking for `validateStack` (https://github.com/pulumi/pulumi-policy/pull/173).
+- Provide easier type checking for `validateStack`, along with `isType` and `asType` helper functions
+  (https://github.com/pulumi/pulumi-policy/pull/173).
+
+  Example:
+
+  ```typescript
+  {
+      validateStack: validateStackResourcesOfType(aws.s3.Bucket, (buckets, args, reportViolation) => {
+          for (const bucket of buckets) {
+              // ...
+          }
+      }),
+  }
+  ```
+
+- `validateTypedResource` is now deprecated in favor of `validateResourceOfType`. `validateTypedResource`
+  will be removed in an upcoming version. (https://github.com/pulumi/pulumi-policy/pull/173).
 
 ## 0.3.0 (2019-11-26)
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pulumi version # should be v1.6.1 or later
     pulumi policy new aws-typescript
     ```
 
-1. Tweak the Policy Pack in the `index.ts` file as desired. The existing policy in the template (which is annotated below) mandates that an AWS S3 bucket not have public read or write permissions enabled. Each Policy must have a unique name, an enforcement level, and a validation function. Here we use `validateTypedResource` that allows us to validate S3 Bucket resources.
+1. Tweak the Policy Pack in the `index.ts` file as desired. The existing policy in the template (which is annotated below) mandates that an AWS S3 bucket not have public read or write permissions enabled. Each Policy must have a unique name, an enforcement level, and a validation function. Here we use `validateResourceOfType` that allows us to validate S3 Bucket resources.
 
     ```typescript
     // Create a new Policy Pack.
@@ -89,9 +89,9 @@ pulumi version # should be v1.6.1 or later
             // simply prints a warning for users, while a "mandatory" policy will block an update from proceeding.
             enforcementLevel: "mandatory",
 
-            // The validateTypedResource function allows you to filter resources. In this case, the rule only
+            // The validateResourceOfType function allows you to filter resources. In this case, the rule only
             // applies to S3 buckets and reports a violation if the acl is "public-read" or "public-read-write".
-            validateResource: validateTypedResource(aws.s3.Bucket, (bucket, args, reportViolation) => {
+            validateResource: validateResourceOfType(aws.s3.Bucket, (bucket, args, reportViolation) => {
                 if (bucket.acl === "public-read" || bucket.acl === "public-read-write") {
                     reportViolation(
                         "You cannot set public-read or public-read-write on an S3 bucket. " +

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -259,9 +259,15 @@ export function validateTypedResources<TResource extends Resource>(
         reportViolation: ReportViolation) => Promise<void> | void,
 ): StackValidation {
     return (args: StackValidationArgs, reportViolation: ReportViolation) => {
-        const resources = filterTypedResources(resourceClass, args.resources);
-        if (resources.length > 0) {
-            validate(resources, args, reportViolation);
+        const isInstance = (<any>resourceClass).isInstance;
+        if (!isInstance || typeof isInstance !== "function") {
+            return;
+        }
+        const filtered = args.resources.filter(r => isInstance({ __pulumiType: r.type }) === true);
+        if (filtered.length > 0) {
+            const filteredTyped = filtered.map(r => r.props as q.ResolvedResource<TResource>);
+            const filteredArgs = { resources: filtered };
+            validate(filteredTyped, filteredArgs, reportViolation);
         }
     };
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -305,6 +305,10 @@ func TestValidateStack(t *testing.T) {
 		{
 			WantErrors: nil,
 		},
+		// Test scenario 9: no violations.
+		{
+			WantErrors: nil,
+		},
 	})
 }
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -233,6 +233,10 @@ func TestValidateResource(t *testing.T) {
 				"  'state' must not have the value 5.",
 			},
 		},
+		// Test scenario 10: no violations.
+		{
+			WantErrors: nil,
+		},
 	})
 }
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -287,6 +287,24 @@ func TestValidateStack(t *testing.T) {
 				"  'state' must not have the value 3.",
 			},
 		},
+		// Test scenario 6: violates the fourth policy.
+		{
+			WantErrors: []string{
+				"  mandatory: Prohibits creating a RandomUuid without any 'keepers'.",
+				"  RandomUuid must not have an empty 'keepers'.",
+			},
+		},
+		// Test scenario 7: violates the fifth policy.
+		{
+			WantErrors: []string{
+				"  mandatory: Prohibits RandomString resources.",
+				"  RandomString resources are not allowed.",
+			},
+		},
+		// Test scenario 8: no violations.
+		{
+			WantErrors: nil,
+		},
 	})
 }
 

--- a/tests/integration/validate_python_resource/policy-pack/index.ts
+++ b/tests/integration/validate_python_resource/policy-pack/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
 
-import { PolicyPack, validateTypedResource } from "@pulumi/policy";
+import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
 import * as random from "@pulumi/random";
 
 new PolicyPack("validate-resource-test-policy", {
@@ -9,7 +9,7 @@ new PolicyPack("validate-resource-test-policy", {
             name: "randomuuid-no-keepers",
             description: "Prohibits creating a RandomUuid without any 'keepers'.",
             enforcementLevel: "mandatory",
-            validateResource: validateTypedResource(random.RandomUuid, (it, args, reportViolation) => {
+            validateResource: validateResourceOfType(random.RandomUuid, (it, args, reportViolation) => {
                 if (!it.keepers || Object.keys(it.keepers).length === 0) {
                     reportViolation("RandomUuid must not have an empty 'keepers'.")
                 }

--- a/tests/integration/validate_resource/policy-pack/index.ts
+++ b/tests/integration/validate_resource/policy-pack/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
 
-import { PolicyPack, validateTypedResource } from "@pulumi/policy";
+import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
 import * as random from "@pulumi/random";
 
 new PolicyPack("validate-resource-test-policy", {
@@ -57,7 +57,7 @@ new PolicyPack("validate-resource-test-policy", {
             name: "randomuuid-no-keepers",
             description: "Prohibits creating a RandomUuid without any 'keepers'.",
             enforcementLevel: "mandatory",
-            validateResource: validateTypedResource(random.RandomUuid, (it, args, reportViolation) => {
+            validateResource: validateResourceOfType(random.RandomUuid, (it, args, reportViolation) => {
                 if (!it.keepers || Object.keys(it.keepers).length === 0) {
                     reportViolation("RandomUuid must not have an empty 'keepers'.")
                 }

--- a/tests/integration/validate_resource/policy-pack/index.ts
+++ b/tests/integration/validate_resource/policy-pack/index.ts
@@ -76,5 +76,26 @@ new PolicyPack("validate-resource-test-policy", {
                 }
             },
         },
+        // Validate other type checks work as expected.
+        {
+            name: "test-type-checks",
+            description: "Policy used to test type checks.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                if (args.type !== "random:index/randomPassword:RandomPassword") {
+                    return;
+                }
+                if (!args.isType(random.RandomPassword)) {
+                    throw new Error("`isType` did not return the expected value.");
+                }
+                const randomPassword = args.asType(random.RandomPassword);
+                if (!randomPassword) {
+                    throw new Error("`asType` did not return the expected value.");
+                }
+                if (randomPassword.length !== 42) {
+                    throw new Error("`randomPassword.length` did not return the expected value.");
+                }
+            },
+        },
     ],
 });

--- a/tests/integration/validate_resource/program/index.ts
+++ b/tests/integration/validate_resource/program/index.ts
@@ -55,4 +55,11 @@ switch (testScenario) {
         // Violates the fifth policy.
         const e = new Resource("e", { state: 5 });
         break;
+
+    case 10:
+        // Create a resource to test the strongly-typed helpers.
+        const pass = new random.RandomPassword("pass", {
+            length: 42,
+        });
+        break;
 }

--- a/tests/integration/validate_stack/policy-pack/index.ts
+++ b/tests/integration/validate_stack/policy-pack/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
 
-import { PolicyPack, validateTypedResources } from "@pulumi/policy";
+import { PolicyPack, validateStackResourcesOfType } from "@pulumi/policy";
 
 import * as random from "@pulumi/random";
 
@@ -84,7 +84,7 @@ new PolicyPack("validate-stack-test-policy", {
             name: "randomuuid-no-keepers",
             description: "Prohibits creating a RandomUuid without any 'keepers'.",
             enforcementLevel: "mandatory",
-            validateStack: validateTypedResources(random.RandomUuid, (resources, args, reportViolation) => {
+            validateStack: validateStackResourcesOfType(random.RandomUuid, (resources, args, reportViolation) => {
                 for (const r of resources) {
                     if (!r.keepers || Object.keys(r.keepers).length === 0) {
                         reportViolation("RandomUuid must not have an empty 'keepers'.");
@@ -134,7 +134,7 @@ new PolicyPack("validate-stack-test-policy", {
             name: "test-args-filtering",
             description: "Policy used to test that `args.resources` is filtered and matches the resources in `resources`.",
             enforcementLevel: "mandatory",
-            validateStack: validateTypedResources(random.RandomInteger, (resources, args, reportViolation) => {
+            validateStack: validateStackResourcesOfType(random.RandomInteger, (resources, args, reportViolation) => {
                 if (resources.length !== args.resources.length) {
                     throw new Error("`args.resources.length` does not match `resources.length`.");
                 }

--- a/tests/integration/validate_stack/policy-pack/index.ts
+++ b/tests/integration/validate_stack/policy-pack/index.ts
@@ -1,12 +1,6 @@
 // Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
 
-import {
-    asTypedResource,
-    filterTypedResources,
-    isTypedResource,
-    PolicyPack,
-    validateTypedResources,
-} from "@pulumi/policy";
+import { PolicyPack, validateTypedResources } from "@pulumi/policy";
 
 import * as random from "@pulumi/random";
 
@@ -37,7 +31,7 @@ new PolicyPack("validate-stack-test-policy", {
 
                     if (r.type === "pulumi-nodejs:dynamic:Resource") {
                         if (r.props.state === 1) {
-                            reportViolation("'state' must not have the value 1.")
+                            reportViolation("'state' must not have the value 1.");
                         }
                     }
                 }
@@ -58,7 +52,7 @@ new PolicyPack("validate-stack-test-policy", {
 
                     if (r.type === "pulumi-nodejs:dynamic:Resource") {
                         if (r.props.state === 2) {
-                            reportViolation("'state' must not have the value 2.")
+                            reportViolation("'state' must not have the value 2.");
                         }
                     }
                 }
@@ -93,7 +87,7 @@ new PolicyPack("validate-stack-test-policy", {
             validateStack: validateTypedResources(random.RandomUuid, (resources, args, reportViolation) => {
                 for (const r of resources) {
                     if (!r.keepers || Object.keys(r.keepers).length === 0) {
-                        reportViolation("RandomUuid must not have an empty 'keepers'.")
+                        reportViolation("RandomUuid must not have an empty 'keepers'.");
                     }
                 }
             }),
@@ -104,9 +98,11 @@ new PolicyPack("validate-stack-test-policy", {
             description: "Prohibits RandomString resources.",
             enforcementLevel: "mandatory",
             validateStack: (args, reportViolation) => {
-                const resources = filterTypedResources(random.RandomString, args.resources);
+                const resources = args.resources
+                    .map(r => r.isType(random.RandomString))
+                    .filter(r => r);
                 if (resources.length > 0) {
-                    reportViolation("RandomString resources are not allowed.")
+                    reportViolation("RandomString resources are not allowed.");
                 }
             },
         },
@@ -120,15 +116,15 @@ new PolicyPack("validate-stack-test-policy", {
                     if (r.type !== "random:index/randomPassword:RandomPassword") {
                         continue;
                     }
-                    if (!isTypedResource(random.RandomPassword, r)) {
-                        throw new Error("`isTypedResource` not returning the expected value.");
+                    if (!r.isType(random.RandomPassword)) {
+                        throw new Error("`isType` did not return the expected value.");
                     }
-                    const randomPassword = asTypedResource(random.RandomPassword, r);
+                    const randomPassword = r.asType(random.RandomPassword);
                     if (!randomPassword) {
-                        throw new Error("`asTypedResource` is not returning the expected value.")
+                        throw new Error("`asType` did not return the expected value.");
                     }
                     if (randomPassword.length !== 42) {
-                        throw new Error("`randomPassword.length` is not returning the expected value.")
+                        throw new Error("`randomPassword.length` did not return the expected value.");
                     }
                 }
             },

--- a/tests/integration/validate_stack/policy-pack/index.ts
+++ b/tests/integration/validate_stack/policy-pack/index.ts
@@ -133,5 +133,21 @@ new PolicyPack("validate-stack-test-policy", {
                 }
             },
         },
+        // Validate that `args.resources` is filtered and matches the resources in `resources`.
+        {
+            name: "test-args-filtering",
+            description: "Policy used to test that `args.resources` is filtered and matches the resources in `resources`.",
+            enforcementLevel: "mandatory",
+            validateStack: validateTypedResources(random.RandomInteger, (resources, args, reportViolation) => {
+                if (resources.length !== args.resources.length) {
+                    throw new Error("`args.resources.length` does not match `resources.length`.");
+                }
+                for (let i = 0; i < resources.length; i++) {
+                    if (resources[i].id !== args.resources[i].props.id) {
+                        throw new Error("`resources[i].id` does not match `args.resources[i].props.id`.");
+                    }
+                }
+            }),
+        },
     ],
 });

--- a/tests/integration/validate_stack/policy-pack/package.json
+++ b/tests/integration/validate_stack/policy-pack/package.json
@@ -3,7 +3,8 @@
     "version": "0.0.1",
     "dependencies": {
         "@pulumi/policy": "latest",
-        "@pulumi/pulumi": "^1.0.0"
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
     },
     "devDependencies": {
         "@types/node": "^8.0.0"

--- a/tests/integration/validate_stack/program/index.ts
+++ b/tests/integration/validate_stack/program/index.ts
@@ -49,5 +49,13 @@ switch (testScenario) {
         const r3 = new random.RandomPassword("r3", {
             length: 42,
         });
-        break
+        break;
+
+    case 9:
+        // Create several resources of the same type to validate
+        // resource filtering by type.
+        const x = new random.RandomInteger("x", { min: 0, max: 10 });
+        const y = new random.RandomInteger("y", { min: 0, max: 10 });
+        const z = new random.RandomInteger("z", { min: 0, max: 10 });
+        break;
 }

--- a/tests/integration/validate_stack/program/index.ts
+++ b/tests/integration/validate_stack/program/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
 
 import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
 import { Resource } from "./resource";
 
 const config = new pulumi.Config();
@@ -30,4 +31,23 @@ switch (testScenario) {
         // Violates the third policy.
         const c = new Resource("c", { state: 3 });
         break;
+
+    case 6:
+        // Violates the fourth policy.
+        const r1 = new random.RandomUuid("r1");
+        break;
+
+    case 7:
+        // Violates the fifth policy.
+        const r2 = new random.RandomString("r2", {
+            length: 10,
+        });
+        break;
+
+    case 8:
+        // Create a resource to test some of the strongly-typed helpers.
+        const r3 = new random.RandomPassword("r3", {
+            length: 42,
+        });
+        break
 }

--- a/tests/integration/validate_stack/program/index.ts
+++ b/tests/integration/validate_stack/program/index.ts
@@ -45,7 +45,7 @@ switch (testScenario) {
         break;
 
     case 8:
-        // Create a resource to test some of the strongly-typed helpers.
+        // Create a resource to test the strongly-typed helpers.
         const r3 = new random.RandomPassword("r3", {
             length: 42,
         });

--- a/tests/integration/validate_stack/program/package.json
+++ b/tests/integration/validate_stack/program/package.json
@@ -4,6 +4,7 @@
         "@types/node": "^8.0.0"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0"
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
     }
 }


### PR DESCRIPTION
- Deprecate `validateTypedResource` in favor of `validateResourceOfType`.
- Add `validateStackResourcesOfType` for strongly-type stack validations.
- Add `isType` and `asType` helper methods.

Usage:

```typescript
validateResource: validateResourceOfType(aws.s3.Bucket, (resource, args, reportViolation) => {
    // ...
});
```

```typescript
validateStack: validateStackResourcesOfType(aws.s3.Bucket, (resources, args, reportViolation) => {
    // ...
});
```

```typescript
if (resource.isType(aws.s3.Bucket) { ... }
```

```typescript
const bucket = resource.asType(aws.s3.Bucket);
if (bucket) { ... }
```

```typescript
const buckets = args.resources.map(r => r.asType(aws.s3.Bucket)).filter(b => b);
```

---
~This adds the following helper functions for use with `validateStack`:~
- ~`validateTypedResources` - similar to `validateResource`'s `validateTypedResource`.~
- ~`isTypedResource` - for checking if a `PolicyResource` is a resource type.~
- ~`asTypedResource` - for converting a `PolicyResource` to a strongly typed object.~
- ~`filterTypedResources` - for filtering an array of `PolicyResource`s to strongly-typed array.~

Fixes #158