### PR TITLE
Inline `asyncTest` utility function

### DIFF
--- a/sdk/nodejs/policy/tests/deserialize.spec.ts
+++ b/sdk/nodejs/policy/tests/deserialize.spec.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import { Inputs, runtime, secret } from "@pulumi/pulumi";
-import { asyncTest } from "@pulumi/pulumi/tests/util";
 import * as assert from "assert";
 import { deserializeProperties } from "../deserialize";
 
@@ -136,3 +135,25 @@ describe("runtime", () => {
         });
     });
 });
+
+type MochaFunc = (err: Error) => void;
+
+// A helper function for wrapping some of the boilerplate goo necessary to interface between Mocha's asynchronous
+// testing and our TypeScript async tests.
+function asyncTest(test: () => Promise<void>): (func: MochaFunc) => void {
+    return (done: (err: any) => void) => {
+        const go = async () => {
+            let caught: Error | undefined;
+            try {
+                await test();
+            }
+            catch (err) {
+                caught = err;
+            }
+            finally {
+                done(caught);
+            }
+        };
+        go();
+    };
+}


### PR DESCRIPTION
We recently made a [change](https://github.com/pulumi/pulumi/pull/3809) in `@pulumi/pulumi` to mark this internal helper as `@internal` so that it would not be emitted in API docs. But TypeScript respects the `@internal` when attempting to use the API from an external package, so attempting to import `asyncTest` here no longer works. In this case, this utility code is simple enough to just copy over into this repository, rather than other workarounds to maintain using it as a dependency.