### PR TITLE
Report violation when accessing unknowns during stack validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - `validateTypedResource` is now deprecated in favor of `validateResourceOfType`. `validateTypedResource`
   will be removed in an upcoming version. (https://github.com/pulumi/pulumi-policy/pull/173).
 
+- Attempting to access an unknown property value during previews from a stack validation callback now results
+  in an advisory violation like what happens when doing the same from a resource validation callback
+  (https://github.com/pulumi/pulumi-policy/pull/180).
+
 ## 0.3.0 (2019-11-26)
 
 ### Improvements

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -255,7 +255,8 @@ function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersion: strin
                     const resources: PolicyResource[] = [];
                     for (const r of req.getResourcesList()) {
                         const type = r.getType();
-                        const props = r.getProperties().toJavaScript();
+                        const deserd = deserializeProperties(r.getProperties());
+                        const props = unknownCheckingProxy(deserd);
                         resources.push({
                             type: type,
                             props: props,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -43,7 +43,7 @@ func abortIfFailed(t *testing.T) {
 type policyTestScenario struct {
 	// WantErrors is the error message we expect to see in the command's output.
 	WantErrors []string
-	// Whether the error messages are advisory, and don't actually fail the command.
+	// Whether the error messages are advisory, and don't actually fail the operation.
 	Advisory bool
 }
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -43,6 +43,8 @@ func abortIfFailed(t *testing.T) {
 type policyTestScenario struct {
 	// WantErrors is the error message we expect to see in the command's output.
 	WantErrors []string
+	// Whether the error messages are advisory, and don't actually fail the command.
+	Advisory bool
 }
 
 // runPolicyPackIntegrationTest creates a new Pulumi stack and then runs through
@@ -147,7 +149,12 @@ func runPolicyPackIntegrationTest(
 				t.Log("No errors are expected.")
 				e.RunCommand(cmd, args...)
 			} else {
-				stdout, stderr := e.RunCommandExpectError(cmd, args...)
+				var stdout, stderr string
+				if scenario.Advisory {
+					stdout, stderr = e.RunCommand(cmd, args...)
+				} else {
+					stdout, stderr = e.RunCommandExpectError(cmd, args...)
+				}
 
 				for _, wantErr := range scenario.WantErrors {
 					inSTDOUT := strings.Contains(stdout, wantErr)
@@ -312,6 +319,22 @@ func TestValidateStack(t *testing.T) {
 		// Test scenario 9: no violations.
 		{
 			WantErrors: nil,
+		},
+	})
+}
+
+// Test that accessing unknown values returns an error during previews.
+func TestUnknownValues(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "unknown_values", NodeJS, map[string]string{
+		"aws:region": "us-west-2",
+	}, []policyTestScenario{
+		{
+			WantErrors: []string{
+				"  advisory: can't run policy 'unknown-values-stack-validation' during preview: string value at .prefix can't be known during preview",
+				"random:index:RandomPet (pet):",
+				"advisory: can't run policy 'unknown-values-resource-validation' during preview: string value at .prefix can't be known during preview",
+			},
+			Advisory: true,
 		},
 	})
 }

--- a/tests/integration/unknown_values/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/unknown_values/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs

--- a/tests/integration/unknown_values/policy-pack/index.ts
+++ b/tests/integration/unknown_values/policy-pack/index.ts
@@ -1,0 +1,32 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import { PolicyPack, validateStackResourcesOfType, validateResourceOfType } from "@pulumi/policy";
+
+import * as random from "@pulumi/random";
+
+new PolicyPack("unknown-values-policy", {
+    policies: [
+        {
+            name: "unknown-values-resource-validation",
+            description: "Accessing unknown values during preview results in a violation.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(random.RandomPet, (pet, args, reportViolation) => {
+                // Accessing `.prefix` is expected to result in a policy violation because its value is unknown
+                // during previews given the associated Pulumi program.
+                console.log(pet.prefix);
+            }),
+        },
+        {
+            name: "unknown-values-stack-validation",
+            description: "Accessing unknown values during preview results in a violation.",
+            enforcementLevel: "mandatory",
+            validateStack: validateStackResourcesOfType(random.RandomPet, (pets, args, reportViolation) => {
+                for (const pet of pets) {
+                    // Accessing `.prefix` is expected to result in a policy violation because its value is unknown
+                    // during previews given the associated Pulumi program.
+                    console.log(pet.prefix);
+                }
+            }),
+        },
+    ],
+});

--- a/tests/integration/unknown_values/policy-pack/package.json
+++ b/tests/integration/unknown_values/policy-pack/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "unknown-values-policy",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/unknown_values/policy-pack/tsconfig.json
+++ b/tests/integration/unknown_values/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/unknown_values/program/Pulumi.yaml
+++ b/tests/integration/unknown_values/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: unknown_values
+runtime: nodejs
+description: A program that creates a resource with an unknown value.

--- a/tests/integration/unknown_values/program/index.ts
+++ b/tests/integration/unknown_values/program/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as random from "@pulumi/random";
+
+const str = new random.RandomString("str", {
+    length: 10,
+});
+
+const pet = new random.RandomPet("pet", {
+    prefix: str.result,
+});

--- a/tests/integration/unknown_values/program/package.json
+++ b/tests/integration/unknown_values/program/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "unknown_values",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/random": "^1.1.0"
+    }
+}

--- a/tests/integration/unknown_values/program/tsconfig.json
+++ b/tests/integration/unknown_values/program/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
For resource validations, an advisory violation is reported when accessing unknown values. We weren't doing this for stack validations.

This change fixes it for stack validations, and adds an integration test that ensures we're doing it for both resource and stack validations.

Fixes #178