### PR TITLE
Prepare CHANGELOG for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+## 0.4.0 (2020-01-30)
+
 ### Improvements
 
 - Add support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs


### PR DESCRIPTION
Once this is merged, I'll tag the merged commit as `v0.4.0`.