### PR TITLE
Expose options, parent, deps, and provider config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
 install:
     # Install Pulumi 🍹
-    - curl -fsSL https://get.pulumi.com/ | bash
+    - curl -fsSL https://get.pulumi.com/ | bash -s -- --version "1.11.0-alpha.1581120694"
     - export PATH="$HOME/.pulumi/bin:$PATH"
     # Install other tools.
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## HEAD (Unreleased)
 
+### Improvements
+
+- Expose options, parent, dependencies, and provider config (https://github.com/pulumi/pulumi-policy/pull/184).
+
 ## 0.4.0 (2020-01-30)
 
 ### Improvements
 
 - Add support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs
-  via upgraded dependency on `@pulumi/pulumi` v1.8.0 (requires v1.8.0 of the Pulumi SDK).
+  via upgraded dependency on `@pulumi/pulumi` v1.8.0 (requires v1.8.0 or later of the Pulumi SDK) (https://github.com/pulumi/pulumi-policy/pull/169).
 
 - Provide easier type checking for `validateStack`, along with `isType` and `asType` helper functions
   (https://github.com/pulumi/pulumi-policy/pull/173).

--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -18,6 +18,6 @@
         "istanbul": "^0.4.5",
         "mocha": "^3.5.0",
         "tslint": "^5.11.0",
-        "typescript": "^3.0.0"
+        "typescript": "^3.7.5"
     }
 }

--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-policy",
     "dependencies": {
-        "@pulumi/pulumi": "^1.8.0",
+        "@pulumi/pulumi": "1.11.0-alpha.1581120694",
         "google-protobuf": "^3.5.0",
         "grpc": "^1.20.2",
         "protobufjs": "^6.8.6"

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -143,7 +143,7 @@ export interface ResourceValidationArgs {
     type: string;
 
     /**
-     * The properties of the resource.
+     * The inputs of the resource.
      */
     props: Record<string, any>;
 
@@ -157,9 +157,15 @@ export interface ResourceValidationArgs {
      */
     name: string;
 
-    // TODO: Add support for the following:
-    //
-    // opts: PolicyResourceOptions;
+    /**
+     * The options of the resource.
+     */
+    opts: PolicyResourceOptions;
+
+    /**
+     * The provider of the resource.
+     */
+    provider?: PolicyProviderResource;
 
     /**
      * Returns true if the type of this resource is the same as `resourceClass`.
@@ -192,6 +198,85 @@ export interface ResourceValidationArgs {
     asType<TResource extends Resource, TArgs>(
         resourceClass: { new(name: string, args: TArgs, ...rest: any[]): TResource },
     ): Unwrap<NonNullable<TArgs>> | undefined;
+}
+
+/**
+ * PolicyResourceOptions is the bag of settings that control a resource's behavior.
+ */
+export interface PolicyResourceOptions {
+    /**
+     * When set to true, protect ensures this resource cannot be deleted.
+     */
+    protect: boolean;
+
+    /**
+     * Ignore changes to any of the specified properties.
+     */
+    ignoreChanges: string[];
+
+    /**
+     * When set to true, indicates that this resource should be deleted before
+     * its replacement is created when replacement is necessary.
+     */
+    deleteBeforeReplace?: boolean;
+
+    /**
+     * Additional URNs that should be aliased to this resource.
+     */
+    aliases: string[];
+
+    /**
+     * Custom timeouts for resource create, update, and delete operations.
+     */
+    customTimeouts: PolicyCustomTimeouts;
+
+    /**
+     * Outputs that should always be treated as secrets.
+     */
+    additionalSecretOutputs: string[];
+}
+
+/**
+ * Custom timeout options.
+ */
+export interface PolicyCustomTimeouts {
+    /**
+     * The create resource timeout.
+     */
+    createSeconds: number;
+    /**
+     * The update resource timeout.
+     */
+    updateSeconds: number;
+    /**
+     * The delete resource timeout.
+     */
+    deleteSeconds: number;
+}
+
+/**
+ * Information about the provider.
+ */
+export interface PolicyProviderResource {
+    /**
+     * The type of the resource provider.
+     */
+    type: string;
+
+    /**
+     * The properties of the resource provider.
+     */
+    props: Record<string, any>;
+
+    /**
+     * The URN of the resource provider.
+     */
+    urn: string;
+
+    /**
+     * The name of the resource provider.
+     */
+    name: string;
 }
 
 /**
@@ -298,9 +383,30 @@ export interface PolicyResource {
      */
     name: string;
 
-    // TODO: Add support for the following:
-    //
-    // opts: PolicyResourceOptions;
+    /**
+     * The options of the resource.
+     */
+    opts: PolicyResourceOptions;
+
+    /**
+     * The provider of the resource.
+     */
+    provider?: PolicyProviderResource;
+
+    /**
+     * An optional parent that this resource belongs to.
+     */
+    parent?: PolicyResource;
+
+    /**
+     * The dependencies of the resource.
+     */
+    dependencies: PolicyResource[];
+
+    /**
+     * The set of dependencies that affect each property.
+     */
+    propertyDependencies: Record<string, PolicyResource[]>;
 
     /**
      * Returns true if the type of this resource is the same as `resourceClass`.

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -346,3 +346,27 @@ func TestRuntimeData(t *testing.T) {
 		"aws:region":   "us-west-2",
 	}, []policyTestScenario{{WantErrors: nil}})
 }
+
+// Test resource options.
+func TestResourceOptions(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "resource_options", NodeJS, nil, []policyTestScenario{
+		// Test scenario 1: test resource options.
+		{WantErrors: nil},
+		// Test scenario 2: prepare for destroying the stack (unprotect protected resources).
+		{WantErrors: nil},
+	})
+}
+
+// Test parent and dependencies.
+func TestParentDependencies(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "parent_dependencies", NodeJS, nil, []policyTestScenario{
+		{WantErrors: nil},
+	})
+}
+
+// Test provider.
+func TestProvider(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "provider", NodeJS, nil, []policyTestScenario{
+		{WantErrors: nil},
+	})
+}

--- a/tests/integration/parent_dependencies/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/parent_dependencies/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs

--- a/tests/integration/parent_dependencies/policy-pack/index.ts
+++ b/tests/integration/parent_dependencies/policy-pack/index.ts
@@ -1,0 +1,73 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as assert from "assert";
+
+import { PolicyPack, PolicyResource } from "@pulumi/policy";
+
+new PolicyPack("parent-dependencies-test-policy", {
+    policies: [
+        {
+            name: "validate-stack",
+            description: "Validates parent and dependencies during `validateStack`.",
+            enforcementLevel: "mandatory",
+            validateStack: (args, reportViolation) => {
+                for (const r of args.resources) {
+                    validate(args.resources, r);
+                }
+            },
+        },
+    ],
+});
+
+function validate(resources: PolicyResource[], r: PolicyResource) {
+    const stack = resources.find(r => r.type === "pulumi:pulumi:Stack");
+    assert.notStrictEqual(stack, undefined);
+
+    switch (r.type) {
+        case "pulumi:pulumi:Stack":
+        case "pulumi:providers:pulumi-nodejs":
+        case "pulumi:providers:random":
+            assert.strictEqual(r.parent, undefined);
+            assert.deepStrictEqual(r.dependencies, []);
+            assert.deepStrictEqual(r.propertyDependencies, {});
+            break;
+
+        case "pulumi-nodejs:dynamic:Resource":
+            switch (r.name) {
+                case "child":
+                    const parent = resources.find(r => r.name === "parent");
+                    assert.notStrictEqual(parent, undefined);
+                    assert.strictEqual(r.parent, parent);
+                    assert.deepStrictEqual(r.dependencies, []);
+                    assert.deepStrictEqual(r.propertyDependencies, {});
+                    break;
+
+                case "b":
+                    assert.strictEqual(r.parent, stack);
+                    const a = resources.find(r => r.name === "a");
+                    assert.notStrictEqual(a, undefined);
+                    assert.strictEqual(r.dependencies.length, 1);
+                    assert.strictEqual(r.dependencies[0], a);
+                    assert.deepStrictEqual(r.propertyDependencies, {});
+                    break;
+            }
+            break;
+
+        case "random:index/randomString:RandomString":
+            assert.strictEqual(r.parent, stack);
+            assert.deepStrictEqual(r.dependencies, []);
+            assert.deepStrictEqual(r.propertyDependencies, {});
+            break;
+
+        case "random:index/randomPet:RandomPet":
+            assert.strictEqual(r.parent, stack);
+            const str = resources.find(r => r.name === "str");
+            assert.notStrictEqual(str, undefined);
+            assert.deepStrictEqual(r.dependencies, [str]);
+            assert.deepStrictEqual(r.propertyDependencies, { prefix: [str] });
+            break;
+
+        default:
+            throw Error(`Unexpected resource of type: '${r.type}'.`);
+    }
+}

--- a/tests/integration/parent_dependencies/policy-pack/package.json
+++ b/tests/integration/parent_dependencies/policy-pack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "parent-dependencies-policy-pack",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/parent_dependencies/policy-pack/tsconfig.json
+++ b/tests/integration/parent_dependencies/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/parent_dependencies/program/Pulumi.yaml
+++ b/tests/integration/parent_dependencies/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: parent_dependencies
+runtime: nodejs
+description: A program that creates some resources for testing a resource's parent and dependencies.

--- a/tests/integration/parent_dependencies/program/index.ts
+++ b/tests/integration/parent_dependencies/program/index.ts
@@ -1,0 +1,24 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as random from "@pulumi/random";
+import { Resource } from "./resource";
+
+// Create resources with a parent/child relationship.
+const parent = new Resource("parent");
+const child = new Resource("child", {
+    parent: parent,
+});
+
+// Create resources with an explicit dependency relationship.
+const a = new Resource("a");
+const b = new Resource("b", {
+    dependsOn: a,
+});
+
+// Create a resource with an implicit dependency relationship.
+const str = new random.RandomString("str", {
+    length: 10,
+});
+const pet = new random.RandomPet("pet", {
+    prefix: str.result,
+});

--- a/tests/integration/parent_dependencies/program/package.json
+++ b/tests/integration/parent_dependencies/program/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "parent-dependencies",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
+    }
+}

--- a/tests/integration/parent_dependencies/program/resource.ts
+++ b/tests/integration/parent_dependencies/program/resource.ts
@@ -1,0 +1,22 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: {},
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    constructor(name: string, opts?: pulumi.CustomResourceOptions) {
+        super(Provider.instance, name, {}, opts);
+    }
+}

--- a/tests/integration/parent_dependencies/program/tsconfig.json
+++ b/tests/integration/parent_dependencies/program/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "resource.ts"
+    ]
+}

--- a/tests/integration/provider/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/provider/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs

--- a/tests/integration/provider/policy-pack/index.ts
+++ b/tests/integration/provider/policy-pack/index.ts
@@ -1,0 +1,76 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as assert from "assert";
+
+import * as pulumi from "@pulumi/pulumi";
+import { PolicyPack, PolicyResource, ResourceValidationArgs } from "@pulumi/policy";
+
+new PolicyPack("resource-options-test-policy", {
+    policies: [
+        {
+            name: "validate-resource",
+            description: "Validates resource options during `validateResource`.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                validate(args);
+            },
+        },
+        {
+            name: "validate-stack",
+            description: "Validates resource options during `validateStack`.",
+            enforcementLevel: "mandatory",
+            validateStack: (args, reportViolation) => {
+                for (const r of args.resources) {
+                    validate(r);
+                }
+            },
+        },
+    ],
+});
+
+function validate(r: ResourceValidationArgs | PolicyResource) {
+    switch (r.type) {
+        case "pulumi:pulumi:Stack":
+        case "pulumi:providers:pulumi-nodejs":
+        case "pulumi:providers:random":
+            assert.strictEqual(r.provider, undefined);
+            break;
+
+        case "pulumi-nodejs:dynamic:Resource":
+            assert.notStrictEqual(r.provider, undefined);
+            assert.strictEqual(r.provider!.type, "pulumi:providers:pulumi-nodejs");
+            assert.strictEqual(r.provider!.name, "default");
+            assert.strictEqual(r.provider!.urn, createURN("pulumi:providers:pulumi-nodejs", "default"));
+            assert.deepStrictEqual(r.provider!.props, {});
+            break;
+
+        case "random:index/randomUuid:RandomUuid":
+            assert.notStrictEqual(r.provider, undefined);
+            assert.strictEqual(r.provider!.type, "pulumi:providers:random");
+            assert.strictEqual(r.provider!.name, "default_1_5_0");
+            assert.strictEqual(r.provider!.urn, createURN("pulumi:providers:random", "default_1_5_0"));
+            assert.notStrictEqual(r.provider!.props, undefined);
+            assert.deepStrictEqual(r.provider!.props.version, "1.5.0");
+            break;
+
+        case "random:index/randomString:RandomString":
+            assert.notStrictEqual(r.provider, undefined);
+            assert.strictEqual(r.provider!.type, "pulumi:providers:random");
+            assert.strictEqual(r.provider!.name, "my-provider");
+            assert.strictEqual(r.provider!.urn, createURN("pulumi:providers:random", "my-provider"));
+            assert.deepStrictEqual(r.provider!.props, {});
+            break;
+
+        default:
+            throw Error(`Unexpected resource of type: '${r.type}'.`);
+    }
+}
+
+/**
+ * Creates a URN from the given `type` and `name`.
+ * @param type the resource type.
+ * @param name the resource name.
+ */
+function createURN(type: string, name: string): string {
+    return `urn:pulumi:${pulumi.getStack()}::${pulumi.getProject()}::${type}::${name}`;
+}

--- a/tests/integration/provider/policy-pack/package.json
+++ b/tests/integration/provider/policy-pack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "provider-policy-pack",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/provider/policy-pack/tsconfig.json
+++ b/tests/integration/provider/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/provider/program/Pulumi.yaml
+++ b/tests/integration/provider/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: provider
+runtime: nodejs
+description: A program that creates some resources for testing providers.

--- a/tests/integration/provider/program/index.ts
+++ b/tests/integration/provider/program/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as random from "@pulumi/random";
+import { Resource } from "./resource";
+
+// Create a dynamic resource.
+const empty = new Resource("empty");
+
+// Create a resource.
+const uuid = new random.RandomUuid("uuid");
+
+// Create a provider and resource that uses it.
+const provider = new random.Provider("my-provider");
+const str = new random.RandomString("str", { length: 10 }, {
+    provider: provider,
+});

--- a/tests/integration/provider/program/package.json
+++ b/tests/integration/provider/program/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "provider",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "1.5.0"
+    }
+}

--- a/tests/integration/provider/program/resource.ts
+++ b/tests/integration/provider/program/resource.ts
@@ -1,0 +1,22 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: {},
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    constructor(name: string, opts?: pulumi.CustomResourceOptions) {
+        super(Provider.instance, name, {}, opts);
+    }
+}

--- a/tests/integration/provider/program/tsconfig.json
+++ b/tests/integration/provider/program/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "resource.ts"
+    ]
+}

--- a/tests/integration/resource_options/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/resource_options/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs

--- a/tests/integration/resource_options/policy-pack/index.ts
+++ b/tests/integration/resource_options/policy-pack/index.ts
@@ -1,0 +1,185 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as assert from "assert";
+
+import * as pulumi from "@pulumi/pulumi";
+import { PolicyPack, PolicyResource, PolicyResourceOptions, ResourceValidationArgs } from "@pulumi/policy";
+
+new PolicyPack("resource-options-test-policy", {
+    policies: [
+        {
+            name: "validate-resource",
+            description: "Validates resource options during `validateResource`.",
+            enforcementLevel: "mandatory",
+            validateResource: (args, reportViolation) => {
+                validate(args);
+            },
+        },
+        {
+            name: "validate-stack",
+            description: "Validates resource options during `validateStack`.",
+            enforcementLevel: "mandatory",
+            validateStack: (args, reportViolation) => {
+                for (const r of args.resources) {
+                    validate(r);
+                }
+            },
+        },
+    ],
+});
+
+function validate(r: ResourceValidationArgs | PolicyResource) {
+    const config = new pulumi.Config();
+    const testScenario = config.requireNumber("scenario");
+
+    // We only validate during the first test scenario. The subsequent test scenario is only
+    // used to unprotect protected resources in preparation for destroying the stack.
+    if (testScenario !== 1) {
+        return;
+    }
+
+    switch (r.type) {
+        case "pulumi:pulumi:Stack":
+        case "pulumi:providers:pulumi-nodejs":
+        case "pulumi:providers:random":
+            assert.deepStrictEqual(r.opts, {
+                protect: false,
+                ignoreChanges: [],
+                aliases: [],
+                additionalSecretOutputs: [],
+                customTimeouts: {
+                    createSeconds: 0,
+                    updateSeconds: 0,
+                    deleteSeconds: 0,
+                },
+            });
+            break;
+
+        case "pulumi-nodejs:dynamic:Resource":
+            validateDynamicResource(r);
+            break;
+
+        case "random:index/randomUuid:RandomUuid":
+            assert.deepStrictEqual(r.opts, {
+                protect: false,
+                ignoreChanges: [],
+                aliases: [],
+                additionalSecretOutputs: [],
+                customTimeouts: {
+                    createSeconds: 0,
+                    updateSeconds: 0,
+                    deleteSeconds: 0,
+                },
+            });
+            break;
+
+        default:
+            throw Error(`Unexpected resource of type: '${r.type}'.`);
+    }
+}
+
+function validateDynamicResource(r: ResourceValidationArgs | PolicyResource) {
+    const defaultOptions: PolicyResourceOptions = {
+        protect: false,
+        ignoreChanges: [],
+        aliases: [],
+        additionalSecretOutputs: [],
+        customTimeouts: {
+            createSeconds: 0,
+            updateSeconds: 0,
+            deleteSeconds: 0,
+        },
+    };
+
+    switch (r.name) {
+        case "empty":
+        case "parent":
+        case "a":
+            assert.deepStrictEqual(r.opts, defaultOptions);
+            break;
+
+        case "protect":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, { protect: true }));
+            break;
+
+        case "ignoreChanges":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, { ignoreChanges: ["foo", "bar"] }));
+            break;
+
+        case "deleteBeforeReplaceNotSet":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions));
+            break;
+
+        case "deleteBeforeReplaceTrue":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, { deleteBeforeReplace: true }));
+            break;
+
+        case "deleteBeforeReplaceFalse":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, { deleteBeforeReplace: false }));
+            break;
+
+        case "aliased":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, {
+                aliases: [createURN("pulumi-nodejs:dynamic:Resource", "old-name-for-aliased")],
+            }));
+            break;
+
+        case "timeouts":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, {
+                customTimeouts: {
+                    createSeconds: 60,
+                    updateSeconds: 120,
+                    deleteSeconds: 180,
+                },
+            }));
+            break;
+
+        case "timeouts-create":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, {
+                customTimeouts: {
+                    createSeconds: 240,
+                    updateSeconds: 0,
+                    deleteSeconds: 0,
+                },
+            }));
+            break;
+
+        case "timeouts-update":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, {
+                customTimeouts: {
+                    createSeconds: 0,
+                    updateSeconds: 300,
+                    deleteSeconds: 0,
+                },
+            }));
+            break;
+
+        case "timeouts-delete":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, {
+                customTimeouts: {
+                    createSeconds: 0,
+                    updateSeconds: 0,
+                    deleteSeconds: 360,
+                },
+            }));
+            break;
+
+        case "secrets":
+            assert.deepStrictEqual(r.opts, Object.assign({}, defaultOptions, {
+                additionalSecretOutputs: ["foo"],
+            }));
+            break;
+
+        default:
+            throw Error(`Unexpected resource with name: '${r.name}'.`);
+    }
+}
+
+/**
+ * Creates a URN from the given `type` and `name`.
+ * @param type the resource type.
+ * @param name the resource name.
+ */
+function createURN(type: string, name: string): string {
+    return `urn:pulumi:${pulumi.getStack()}::${pulumi.getProject()}::${type}::${name}`;
+}

--- a/tests/integration/resource_options/policy-pack/package.json
+++ b/tests/integration/resource_options/policy-pack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "resource-options-policy-pack",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/resource_options/policy-pack/tsconfig.json
+++ b/tests/integration/resource_options/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/resource_options/program/Pulumi.yaml
+++ b/tests/integration/resource_options/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: resource_options
+runtime: nodejs
+description: A program that creates some resources for testing resource options.

--- a/tests/integration/resource_options/program/index.ts
+++ b/tests/integration/resource_options/program/index.ts
@@ -1,0 +1,69 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import { Resource } from "./resource";
+
+const config = new pulumi.Config();
+const testScenario = config.requireNumber("scenario");
+
+// Create a resource that doesn't have any explicit options set.
+const empty = new Resource("empty");
+
+// Create a custom resource that doesn't have any explicit options set.
+const uuid = new random.RandomUuid("uuid");
+
+// Create a protected resource.
+const protect = new Resource("protect", {
+    // Only set `protect` during the first test scenario when the actual tests are run.
+    // Set it to `false` on any other test scenario in preparation for destroying the stack.
+    protect: testScenario === 1,
+});
+
+// Create a resource with ignoreChanges.
+const ignoreChanges = new Resource("ignoreChanges", {
+    ignoreChanges: ["foo", "bar"],
+})
+
+// Create a resource with deleteBeforeReplace.
+const deleteBeforeReplaceNotSet = new Resource("deleteBeforeReplaceNotSet");
+const deleteBeforeReplaceTrue = new Resource("deleteBeforeReplaceTrue", {
+    deleteBeforeReplace: true,
+});
+const deleteBeforeReplaceFalse = new Resource("deleteBeforeReplaceFalse", {
+    deleteBeforeReplace: false,
+});
+
+// Create a resource with an alias to an old name.
+const aliased = new Resource("aliased", {
+    aliases: [{ name: "old-name-for-aliased" }],
+});
+
+// Create resources with custom timeouts.
+const timeouts = new Resource("timeouts", {
+    customTimeouts: {
+        create: "1m",
+        update: "2m",
+        delete: "3m",
+    },
+});
+const timeoutsCreate = new Resource("timeouts-create", {
+    customTimeouts: {
+        create: "4m",
+    },
+});
+const timeoutsUpdate = new Resource("timeouts-update", {
+    customTimeouts: {
+        update: "5m",
+    },
+});
+const timeoutsDelete = new Resource("timeouts-delete", {
+    customTimeouts: {
+        delete: "6m",
+    },
+});
+
+// Create a resource with additional secret outputs.
+const secrets = new Resource("secrets", {
+    additionalSecretOutputs: ["foo"],
+});

--- a/tests/integration/resource_options/program/package.json
+++ b/tests/integration/resource_options/program/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "resource-options",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
+    }
+}

--- a/tests/integration/resource_options/program/resource.ts
+++ b/tests/integration/resource_options/program/resource.ts
@@ -1,0 +1,22 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: {},
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    constructor(name: string, opts?: pulumi.CustomResourceOptions) {
+        super(Provider.instance, name, {}, opts);
+    }
+}

--- a/tests/integration/resource_options/program/tsconfig.json
+++ b/tests/integration/resource_options/program/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "resource.ts"
+    ]
+}

--- a/tests/integration/runtime_data/policy-pack/index.ts
+++ b/tests/integration/runtime_data/policy-pack/index.ts
@@ -4,7 +4,7 @@ import * as assert from "assert";
 
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import { PolicyPack, PolicyResource } from "@pulumi/policy";
+import { PolicyPack, PolicyResource, ResourceValidationArgs } from "@pulumi/policy";
 
 new PolicyPack("runtime-data-policy", {
     policies: [
@@ -29,7 +29,7 @@ new PolicyPack("runtime-data-policy", {
     ],
 });
 
-function verifyData(r: PolicyResource) {
+function verifyData(r: PolicyResource | ResourceValidationArgs) {
     if (r.type !== "pulumi-nodejs:dynamic:Resource") {
         return;
     }


### PR DESCRIPTION
This PR exposes resource options, the resource parent, dependencies, and provider config.

This depends on https://github.com/pulumi/pulumi/pull/3862 (CI will fail until we have a new CLI and SDK release with those changes).

For now, I've only exposed the parent and dependencies for `validateStack`, as we'd previously discussed. We could consider exposing it for `validateResource`, but we'd have to send the graph of parent and dependencies (and their parent and dependencies, and so on) for each resource being analyzed.

Fixes https://github.com/pulumi/pulumi-policy/issues/78
Fixes https://github.com/pulumi/pulumi-policy/issues/153
Fixes https://github.com/pulumi/pulumi-policy/issues/162
Fixes https://github.com/pulumi/pulumi-policy/issues/110