### PR TITLE
get version tag

### DIFF
--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-policy",
     "dependencies": {
-        "@pulumi/pulumi": "1.11.0-alpha.1581120694",
+        "@pulumi/pulumi": "v1.12.0-alpha.1582593116+ge660937b",
         "google-protobuf": "^3.5.0",
         "grpc": "^1.20.2",
         "protobufjs": "^6.8.6"

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -55,9 +55,17 @@ export class PolicyPack {
     constructor(private name: string, args: PolicyPackArgs) {
         this.policies = args.policies;
 
+        // Get package version from the package.json file.
+        const cwd = process.cwd();
+        const pkg = require(`${cwd}/package.json`);
+        const versionTag = pkg.version;
+        if (!versionTag || versionTag === "") {
+            throw new Error("Version must be defined in the package.json file.");
+        }
+
         // TODO: Wire up version information obtained from the service.
         const version = "1";
-        serve(this.name, version, this.policies);
+        serve(this.name, version, versionTag, this.policies);
     }
 }
 

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -63,9 +63,7 @@ export class PolicyPack {
             throw new Error("Version must be defined in the package.json file.");
         }
 
-        // TODO: Wire up version information obtained from the service.
-        const version = "1";
-        serve(this.name, version, versionTag, this.policies);
+        serve(this.name, versionTag, this.policies);
     }
 }
 

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -58,12 +58,12 @@ export class PolicyPack {
         // Get package version from the package.json file.
         const cwd = process.cwd();
         const pkg = require(`${cwd}/package.json`);
-        const versionTag = pkg.version;
-        if (!versionTag || versionTag === "") {
+        const version = pkg.version;
+        if (!version || version === "") {
             throw new Error("Version must be defined in the package.json file.");
         }
 
-        serve(this.name, versionTag, this.policies);
+        serve(this.name, version, this.policies);
     }
 }
 

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -58,9 +58,6 @@ export interface Diagnostic {
     /** Name of the policy pack that the violated policy was a part of. */
     policyPackName: string;
 
-    /** Version of the policy pack. */
-    policyPackVersion: string;
-
     /**
      * A brief description of the policy rule. e.g., "S3 buckets should have default encryption
      * enabled."
@@ -127,7 +124,6 @@ export function makeAnalyzeResponse(ds: Diagnostic[]) {
         const diagnostic = new analyzerproto.AnalyzeDiagnostic();
         diagnostic.setPolicyname(d.policyName);
         diagnostic.setPolicypackname(d.policyPackName);
-        diagnostic.setPolicypackversion(d.policyPackVersion);
         diagnostic.setDescription(d.description);
         diagnostic.setMessage(d.message);
         diagnostic.setEnforcementlevel(mapEnforcementLevel(d.enforcementLevel));

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -83,6 +83,9 @@ export interface Diagnostic {
      * The URN of the resource that has the policy violation.
      */
     urn?: string;
+
+    /** Version tag of the policy pack. */
+    policyPackVersionTag: string;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -93,9 +96,10 @@ export interface Diagnostic {
 // ------------------------------------------------------------------------------------------------
 
 /** @internal */
-export function makeAnalyzerInfo(policyPackName: string, policies: Policies): any {
+export function makeAnalyzerInfo(policyPackName: string, versionTag: string, policies: Policies): any {
     const ai: any = new analyzerproto.AnalyzerInfo();
     ai.setName(policyPackName);
+    ai.setVersiontag(versionTag);
 
     const policyInfos: any[] = [];
     for (const policy of policies) {

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -132,6 +132,7 @@ export function makeAnalyzeResponse(ds: Diagnostic[]) {
         diagnostic.setMessage(d.message);
         diagnostic.setEnforcementlevel(mapEnforcementLevel(d.enforcementLevel));
         diagnostic.setUrn(d.urn);
+        diagnostic.setPolicypackversiontag(d.policyPackVersionTag);
 
         diagnostics.push(diagnostic);
     }

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -58,6 +58,9 @@ export interface Diagnostic {
     /** Name of the policy pack that the violated policy was a part of. */
     policyPackName: string;
 
+    /** Version of the Policy Pack. */
+    policyPackVersion: string;
+
     /**
      * A brief description of the policy rule. e.g., "S3 buckets should have default encryption
      * enabled."
@@ -80,9 +83,6 @@ export interface Diagnostic {
      * The URN of the resource that has the policy violation.
      */
     urn?: string;
-
-    /** Version tag of the policy pack. */
-    policyPackVersionTag: string;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -93,10 +93,10 @@ export interface Diagnostic {
 // ------------------------------------------------------------------------------------------------
 
 /** @internal */
-export function makeAnalyzerInfo(policyPackName: string, versionTag: string, policies: Policies): any {
+export function makeAnalyzerInfo(policyPackName: string, version: string, policies: Policies): any {
     const ai: any = new analyzerproto.AnalyzerInfo();
     ai.setName(policyPackName);
-    ai.setVersiontag(versionTag);
+    ai.setVersion(version);
 
     const policyInfos: any[] = [];
     for (const policy of policies) {
@@ -124,11 +124,11 @@ export function makeAnalyzeResponse(ds: Diagnostic[]) {
         const diagnostic = new analyzerproto.AnalyzeDiagnostic();
         diagnostic.setPolicyname(d.policyName);
         diagnostic.setPolicypackname(d.policyPackName);
+        diagnostic.setPolicypackversion(d.policyPackVersion);
         diagnostic.setDescription(d.description);
         diagnostic.setMessage(d.message);
         diagnostic.setEnforcementlevel(mapEnforcementLevel(d.enforcementLevel));
         diagnostic.setUrn(d.urn);
-        diagnostic.setPolicypackversiontag(d.policyPackVersionTag);
 
         diagnostics.push(diagnostic);
     }

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -151,7 +151,6 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersionTag: string,
                     const diagnosticEvent: Diagnostic = {
                         policyName: name,
                         policyPackName,
-                        policyPackVersion: "",
                         message: violationMessage,
                         urn,
                         policyPackVersionTag,
@@ -207,7 +206,6 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersionTag: string,
                             ds.push({
                                 policyName: name,
                                 policyPackName,
-                                policyPackVersion: "",
                                 message: `can't run policy '${name}' during preview: ${e.message}`,
                                 policyPackVersionTag,
                                 ...diag,
@@ -270,7 +268,6 @@ function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersionTag: st
                     ds.push({
                         policyName: name,
                         policyPackName,
-                        policyPackVersion: "",
                         message: violationMessage,
                         urn,
                         policyPackVersionTag,
@@ -367,7 +364,6 @@ function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersionTag: st
                         ds.push({
                             policyName: name,
                             policyPackName,
-                            policyPackVersion: "",
                             message: `can't run policy '${name}' during preview: ${e.message}`,
                             policyPackVersionTag,
                             ...diag,

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -65,14 +65,13 @@ const packNameRE = "^[a-zA-Z0-9-_.]{1,100}$";
   * be written to STDOUT.
   *
   * @param policyPackName Friendly name of the policy pack.
-  * @param policyPackVersion Version of the policy pack SDK used.
   * @param policyPackVersionTag Version tag of the policy pack SDK used.
   * @param policies The policies to be served.
   * @internal
   */
-export function serve(policyPackName: string, policyPackVersion: string, policyPackVersionTag: string, policies: Policies): void {
+export function serve(policyPackName: string, policyPackVersionTag: string, policies: Policies): void {
     if (!policyPackName || !policyPackName.match(packNameRE)) {
-        console.error(`Invalids policy pack name "${policyPackName}". Policy pack names may only contain alphanumerics, hyphens, underscores, or periods.`);
+        console.error(`Invalid policy pack name "${policyPackName}". Policy pack names may only contain alphanumerics, hyphens, underscores, or periods.`);
         process.exit(1);
     }
 
@@ -88,8 +87,8 @@ export function serve(policyPackName: string, policyPackVersion: string, policyP
     // Finally connect up the gRPC client/server and listen for incoming requests.
     const server = new grpc.Server();
     server.addService(analyzerrpc.AnalyzerService, {
-        analyze: makeAnalyzeRpcFun(policyPackName, policyPackVersion, policyPackVersionTag, policies),
-        analyzeStack: makeAnalyzeStackRpcFun(policyPackName, policyPackVersion, policyPackVersionTag, policies),
+        analyze: makeAnalyzeRpcFun(policyPackName, policyPackVersionTag, policies),
+        analyzeStack: makeAnalyzeStackRpcFun(policyPackName, policyPackVersionTag, policies),
         getAnalyzerInfo: makeGetAnalyzerInfoRpcFun(policyPackName, policyPackVersionTag, policies),
         getPluginInfo: getPluginInfoRpc,
     });
@@ -129,7 +128,7 @@ async function getPluginInfoRpc(call: any, callback: any): Promise<void> {
 
 // analyze is the RPC call that will analyze an individual resource, one at a time, called with the
 // "inputs" to the resource, before it is updated.
-function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, policyPackVersionTag: string, policies: Policies) {
+function makeAnalyzeRpcFun(policyPackName: string, policyPackVersionTag: string, policies: Policies) {
     return async function (call: any, callback: any): Promise<void> {
         // Prep to perform the analysis.
         const req = call.request;
@@ -152,7 +151,7 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
                     const diagnosticEvent: Diagnostic = {
                         policyName: name,
                         policyPackName,
-                        policyPackVersion,
+                        policyPackVersion: "",
                         message: violationMessage,
                         urn,
                         policyPackVersionTag,
@@ -208,7 +207,7 @@ function makeAnalyzeRpcFun(policyPackName: string, policyPackVersion: string, po
                             ds.push({
                                 policyName: name,
                                 policyPackName,
-                                policyPackVersion,
+                                policyPackVersion: "",
                                 message: `can't run policy '${name}' during preview: ${e.message}`,
                                 policyPackVersionTag,
                                 ...diag,
@@ -247,7 +246,7 @@ interface IntermediateStackResource {
 
 // analyzeStack is the RPC call that will analyze all resources within a stack, at the end of a successful
 // preview or update. The provided resources are the "outputs", after any mutations have taken place.
-function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersion: string, policyPackVersionTag: string, policies: Policies) {
+function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersionTag: string, policies: Policies) {
     return async function (call: any, callback: any): Promise<void> {
         // Prep to perform the analysis.
         const req = call.request;
@@ -271,7 +270,7 @@ function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersion: strin
                     ds.push({
                         policyName: name,
                         policyPackName,
-                        policyPackVersion,
+                        policyPackVersion: "",
                         message: violationMessage,
                         urn,
                         policyPackVersionTag,
@@ -368,7 +367,7 @@ function makeAnalyzeStackRpcFun(policyPackName: string, policyPackVersion: strin
                         ds.push({
                             policyName: name,
                             policyPackName,
-                            policyPackVersion,
+                            policyPackVersion: "",
                             message: `can't run policy '${name}' during preview: ${e.message}`,
                             policyPackVersionTag,
                             ...diag,

--- a/sdk/nodejs/policy/tests/pb.spec.ts
+++ b/sdk/nodejs/policy/tests/pb.spec.ts
@@ -43,9 +43,9 @@ describe("mapEnforcementLevel", () => {
 
 describe("makeAnalyzerInfo", () => {
     it("does not throw for reasonable policy packs", () => {
-        assert.doesNotThrow(() => makeAnalyzerInfo("testRules", []));
+        assert.doesNotThrow(() => makeAnalyzerInfo("testRules", "1.0.0", []));
         assert.doesNotThrow(() => {
-            makeAnalyzerInfo("testRules", [
+            makeAnalyzerInfo("testRules", "1.0.0", [
                 {
                     name: "approved-amis-by-id",
                     description: "Instances should use approved AMIs",
@@ -58,7 +58,7 @@ describe("makeAnalyzerInfo", () => {
 
     it("throws for disabled or invalid enforcementLevel", () => {
         assert.throws(() => {
-            makeAnalyzerInfo("testRules", [
+            makeAnalyzerInfo("testRules", "1.0.0", [
                 {
                     name: "approved-amis-by-id",
                     description: "Instances should use approved AMIs",
@@ -68,7 +68,7 @@ describe("makeAnalyzerInfo", () => {
             ]);
         });
         assert.throws(() => {
-            makeAnalyzerInfo("testRules", [
+            makeAnalyzerInfo("testRules", "1.0.0", [
                 {
                     name: "approved-amis-by-id",
                     description: "Instances should use approved AMIs",
@@ -94,6 +94,7 @@ describe("makeAnalyzeResponse", () => {
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: "mandatory",
+                    policyPackVersionTag: "1.0.0",
                 },
             ]);
         });
@@ -107,6 +108,7 @@ describe("makeAnalyzeResponse", () => {
                     message: "Did not use approved AMI",
                     enforcementLevel: "mandatory",
                     urn: "foo",
+                    policyPackVersionTag: "1.0.0",
                 },
             ]);
         });
@@ -122,6 +124,7 @@ describe("makeAnalyzeResponse", () => {
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: "disabled",
+                    policyPackVersionTag: "1.0.0",
                 },
             ]);
         });
@@ -134,6 +137,7 @@ describe("makeAnalyzeResponse", () => {
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: <any>"invalidEnforcementLevel",
+                    policyPackVersionTag: "1.0.0",
                 },
             ]);
         });

--- a/sdk/nodejs/policy/tests/pb.spec.ts
+++ b/sdk/nodejs/policy/tests/pb.spec.ts
@@ -90,10 +90,10 @@ describe("makeAnalyzeResponse", () => {
                 {
                     policyName: "approved-amis-by-id",
                     policyPackName: "awsSecRules",
+                    policyPackVersion: "1.0.0",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: "mandatory",
-                    policyPackVersionTag: "1.0.0",
                 },
             ]);
         });
@@ -102,11 +102,11 @@ describe("makeAnalyzeResponse", () => {
                 {
                     policyName: "approved-amis-by-id",
                     policyPackName: "awsSecRules",
+                    policyPackVersion: "1.0.0",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: "mandatory",
                     urn: "foo",
-                    policyPackVersionTag: "1.0.0",
                 },
             ]);
         });
@@ -118,10 +118,10 @@ describe("makeAnalyzeResponse", () => {
                 {
                     policyName: "approved-amis-by-id",
                     policyPackName: "awsSecRules",
+                    policyPackVersion: "1.0.0",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: "disabled",
-                    policyPackVersionTag: "1.0.0",
                 },
             ]);
         });
@@ -130,10 +130,10 @@ describe("makeAnalyzeResponse", () => {
                 {
                     policyName: "approved-amis-by-id",
                     policyPackName: "awsSecRules",
+                    policyPackVersion: "1.0.0",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: <any>"invalidEnforcementLevel",
-                    policyPackVersionTag: "1.0.0",
                 },
             ]);
         });

--- a/sdk/nodejs/policy/tests/pb.spec.ts
+++ b/sdk/nodejs/policy/tests/pb.spec.ts
@@ -90,7 +90,6 @@ describe("makeAnalyzeResponse", () => {
                 {
                     policyName: "approved-amis-by-id",
                     policyPackName: "awsSecRules",
-                    policyPackVersion: "1",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: "mandatory",
@@ -103,7 +102,6 @@ describe("makeAnalyzeResponse", () => {
                 {
                     policyName: "approved-amis-by-id",
                     policyPackName: "awsSecRules",
-                    policyPackVersion: "1",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: "mandatory",
@@ -120,7 +118,6 @@ describe("makeAnalyzeResponse", () => {
                 {
                     policyName: "approved-amis-by-id",
                     policyPackName: "awsSecRules",
-                    policyPackVersion: "1",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: "disabled",
@@ -133,7 +130,6 @@ describe("makeAnalyzeResponse", () => {
                 {
                     policyName: "approved-amis-by-id",
                     policyPackName: "awsSecRules",
-                    policyPackVersion: "1",
                     description: "Instances should use approved AMIs",
                     message: "Did not use approved AMI",
                     enforcementLevel: <any>"invalidEnforcementLevel",


### PR DESCRIPTION
Related to https://github.com/pulumi/pulumi-policy/issues/41

We previously has a hard coded "version" here that was just a 1. I decided to remove that and all uses of it since it was basically a fake value. 

This will fail until we have a new version of the CLI released -- we may choose to pin to a dev build.