### PR TITLE
Fix async policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Expose options, parent, dependencies, and provider config (https://github.com/pulumi/pulumi-policy/pull/184).
 
+- Fix issue that prevented async policies from failing as expected when using `validateResourceOfType` or
+  `validateStackResourcesOfType` (https://github.com/pulumi/pulumi-policy/pull/202).
+
 ## 0.4.0 (2020-01-30)
 
 ### Improvements

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -305,7 +305,7 @@ export function validateResourceOfType<TResource extends Resource, TArgs>(
 ): ResourceValidation {
     return (args: ResourceValidationArgs, reportViolation: ReportViolation) => {
         if (args.isType(resourceClass)) {
-            validate(args.props as Unwrap<NonNullable<TArgs>>, args, reportViolation);
+            return validate(args.props as Unwrap<NonNullable<TArgs>>, args, reportViolation);
         }
     };
 }
@@ -474,7 +474,7 @@ export function validateStackResourcesOfType<TResource extends Resource>(
         if (filtered.length > 0) {
             const filteredTyped = filtered.map(r => r.props as q.ResolvedResource<TResource>);
             const filteredArgs = { resources: filtered };
-            validate(filteredTyped, filteredArgs, reportViolation);
+            return validate(filteredTyped, filteredArgs, reportViolation);
         }
     };
 }

--- a/sdk/nodejs/policy/tests/deserialize.spec.ts
+++ b/sdk/nodejs/policy/tests/deserialize.spec.ts
@@ -15,6 +15,7 @@
 import { Inputs, runtime, secret } from "@pulumi/pulumi";
 import * as assert from "assert";
 import { deserializeProperties } from "../deserialize";
+import { asyncTest } from "./util";
 
 const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
 
@@ -135,25 +136,3 @@ describe("runtime", () => {
         });
     });
 });
-
-type MochaFunc = (err: Error) => void;
-
-// A helper function for wrapping some of the boilerplate goo necessary to interface between Mocha's asynchronous
-// testing and our TypeScript async tests.
-function asyncTest(test: () => Promise<void>): (func: MochaFunc) => void {
-    return (done: (err: any) => void) => {
-        const go = async () => {
-            let caught: Error | undefined;
-            try {
-                await test();
-            }
-            catch (err) {
-                caught = err;
-            }
-            finally {
-                done(caught);
-            }
-        };
-        go();
-    };
-}

--- a/sdk/nodejs/policy/tests/policy.spec.ts
+++ b/sdk/nodejs/policy/tests/policy.spec.ts
@@ -1,0 +1,112 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+
+import * as pulumi from "@pulumi/pulumi";
+import {
+    ResourceValidationPolicy,
+    StackValidationPolicy,
+    validateResourceOfType,
+    validateStackResourcesOfType,
+} from "../policy";
+
+import { asyncTest, runResourcePolicy, runStackPolicy } from "./util";
+
+function delay(t: number, v: string): Promise<string> {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(v), t);
+    });
+}
+
+class Foo extends pulumi.Resource {
+    constructor(name: string, args: FooArgs) {
+        super("my:foo", name, false);
+    }
+}
+
+interface FooArgs {
+}
+
+const empytOptions = {
+    protect: false,
+    ignoreChanges: [],
+    aliases: [],
+    customTimeouts: {
+        createSeconds: 0,
+        updateSeconds: 0,
+        deleteSeconds: 0,
+    },
+    additionalSecretOutputs: [],
+};
+
+describe("validateResourceOfType", () => {
+    it("works as expected with async policies", asyncTest(async () => {
+        const policy: ResourceValidationPolicy = {
+            name: "foo",
+            description: "A test policy.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(Foo, async (_, __, reportViolation) => {
+                const response = await delay(100, "hi");
+                reportViolation(response);
+            }),
+        };
+
+        const args = {
+            isType: () => true,  // true so the validation function always runs.
+            asType: () => undefined,
+            type: "",
+            props: {},
+            urn: "",
+            name: "",
+            opts: empytOptions,
+        };
+
+        const violations = await runResourcePolicy(policy, args);
+
+        assert.deepStrictEqual(violations, [{ message: "hi" }]);
+    }));
+});
+
+describe("validateStackResourcesOfType", () => {
+    it("works as expected with async policies", asyncTest(async () => {
+        const policy: StackValidationPolicy = {
+            name: "foo",
+            description: "A test policy.",
+            enforcementLevel: "mandatory",
+            validateStack: validateStackResourcesOfType(Foo, async (_, __, reportViolation) => {
+                const response = await delay(100, "hi");
+                reportViolation(response);
+            }),
+        };
+
+        const args = {
+            resources: [{
+                isType: () => true, // true so the validation function always runs.
+                asType: () => undefined,
+                type: "",
+                props: {},
+                urn: "",
+                name: "",
+                opts: empytOptions,
+                dependencies: [],
+                propertyDependencies: {},
+            }],
+        };
+
+        const violations = await runStackPolicy(policy, args);
+
+        assert.deepStrictEqual(violations, [{ message: "hi" }]);
+    }));
+});

--- a/sdk/nodejs/policy/tests/util.ts
+++ b/sdk/nodejs/policy/tests/util.ts
@@ -1,0 +1,69 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as policy from "../policy";
+
+export type MochaFunc = (err: Error) => void;
+
+// A helper function for wrapping some of the boilerplate goo necessary to interface between Mocha's asynchronous
+// testing and our TypeScript async tests.
+export function asyncTest(test: () => Promise<void>): (func: MochaFunc) => void {
+    return (done: (err: any) => void) => {
+        const go = async () => {
+            let caught: Error | undefined;
+            try {
+                await test();
+            }
+            catch (err) {
+                caught = err;
+            }
+            finally {
+                done(caught);
+            }
+        };
+        go();
+    };
+}
+
+export interface PolicyViolation {
+    message: string;
+    urn?: string;
+}
+
+// runResourcePolicy will run some basic checks for a policy's metadata, and then
+// execute its rules with the provided type and properties.
+export async function runResourcePolicy(resPolicy: policy.ResourceValidationPolicy, args: policy.ResourceValidationArgs): Promise<PolicyViolation[]> {
+    const violations: PolicyViolation[] = [];
+    const report = (message: string, urn?: string) => {
+        violations.push({ message: message, ...urn && { urn } });
+    };
+    const validations = Array.isArray(resPolicy.validateResource)
+        ? resPolicy.validateResource
+        : [resPolicy.validateResource];
+    for (const validation of validations) {
+        await Promise.resolve(validation(args, report));
+    }
+    return violations;
+}
+
+// runStackPolicy will run some basic checks for a policy's metadata, and then
+// execute its rules with the provided type and properties.
+export async function runStackPolicy(stackPolicy: policy.StackValidationPolicy, args: policy.StackValidationArgs): Promise<PolicyViolation[]> {
+    const violations: PolicyViolation[] = [];
+    const report = (message: string, urn?: string) => {
+        violations.push({ message: message, ...urn && { urn } });
+    };
+    await Promise.resolve(stackPolicy.validateStack(args, report));
+    return violations;
+}

--- a/sdk/nodejs/policy/tsconfig.json
+++ b/sdk/nodejs/policy/tsconfig.json
@@ -26,6 +26,8 @@
 
         "tests/deserialize.spec.ts",
         "tests/pb.spec.ts",
-        "tests/proxy.spec.ts"
+        "tests/policy.spec.ts",
+        "tests/proxy.spec.ts",
+        "tests/util.ts"
     ]
 }

--- a/sdk/nodejs/tslint.json
+++ b/sdk/nodejs/tslint.json
@@ -15,7 +15,7 @@
         "eofline": true,
         "file-header": [
             true,
-            "Copyright 2016-2019, Pulumi Corporation."
+            "Copyright \\d{4}-\\d{4}, Pulumi Corporation."
         ],
         "forin": true,
         "indent": [


### PR DESCRIPTION
Async policies weren't failing as expected when the `validateResourceOfType` or `validateStackResourcesOfType` helpers are used because the result of the validation function wasn't being returned. Regression tests fail before the change and succeed after.

Fixes #199