### PR TITLE
Add `enforcementLevel` to `PolicyPackArgs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Fix issue that prevented async policies from failing as expected when using `validateResourceOfType` or
   `validateStackResourcesOfType` (https://github.com/pulumi/pulumi-policy/pull/202).
 
+- Added a top-level optional `enforcementLevel` on `PolicyPackArgs` and made `enforcementLevel` on `Policy` optional.
+  This allows setting the enforcement level at the Policy Pack level which will apply to all policies. Individual
+  policies can set their own `enforcementLevel` to override the value specified for the Policy Pack. If no enforcement
+  level is specified for either the Policy Pack or Policy, `"advisory"` is used.
+  (https://github.com/pulumi/pulumi-policy/issues/192).
+
 ## 0.4.0 (2020-01-30)
 
 ### Improvements

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -16,6 +16,8 @@ import { Resource, Unwrap } from "@pulumi/pulumi";
 import * as q from "@pulumi/pulumi/queryable";
 import { serve } from "./server";
 
+const defaultEnforcementLevel: EnforcementLevel = "advisory";
+
 /**
  * The set of arguments for constructing a PolicyPack.
  */
@@ -24,6 +26,13 @@ export interface PolicyPackArgs {
      * The policies associated with a PolicyPack.
      */
     policies: Policies;
+
+    /**
+     * Indicates what to do on policy violation, e.g., block deployment but allow override with
+     * proper permissions. Default for all policies in the PolicyPack. Individual policies can
+     * override.
+     */
+    enforcementLevel?: EnforcementLevel;
 }
 
 /**
@@ -63,7 +72,8 @@ export class PolicyPack {
             throw new Error("Version must be defined in the package.json file.");
         }
 
-        serve(this.name, version, this.policies);
+        const enforcementLevel = args.enforcementLevel || defaultEnforcementLevel;
+        serve(this.name, version, enforcementLevel, this.policies);
     }
 }
 
@@ -91,7 +101,7 @@ export interface Policy {
      * Indicates what to do on policy violation, e.g., block deployment but allow override with
      * proper permissions.
      */
-    enforcementLevel: EnforcementLevel;
+    enforcementLevel?: EnforcementLevel;
 }
 
 /**

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -93,17 +93,22 @@ export interface Diagnostic {
 // ------------------------------------------------------------------------------------------------
 
 /** @internal */
-export function makeAnalyzerInfo(policyPackName: string, version: string, policies: Policies): any {
+export function makeAnalyzerInfo(
+    policyPackName: string,
+    policyPackVersion: string,
+    policyPackEnforcementLevel: EnforcementLevel,
+    policies: Policies,
+): any {
     const ai: any = new analyzerproto.AnalyzerInfo();
     ai.setName(policyPackName);
-    ai.setVersion(version);
+    ai.setVersion(policyPackVersion);
 
     const policyInfos: any[] = [];
     for (const policy of policies) {
         const policyInfo = new analyzerproto.PolicyInfo();
         policyInfo.setName(policy.name);
         policyInfo.setDescription(policy.description);
-        policyInfo.setEnforcementlevel(mapEnforcementLevel(policy.enforcementLevel));
+        policyInfo.setEnforcementlevel(mapEnforcementLevel(policy.enforcementLevel || policyPackEnforcementLevel));
 
         policyInfos.push(policyInfo);
     }

--- a/sdk/nodejs/policy/tests/pb.spec.ts
+++ b/sdk/nodejs/policy/tests/pb.spec.ts
@@ -43,9 +43,9 @@ describe("mapEnforcementLevel", () => {
 
 describe("makeAnalyzerInfo", () => {
     it("does not throw for reasonable policy packs", () => {
-        assert.doesNotThrow(() => makeAnalyzerInfo("testRules", "1.0.0", []));
+        assert.doesNotThrow(() => makeAnalyzerInfo("testRules", "1.0.0", "advisory", []));
         assert.doesNotThrow(() => {
-            makeAnalyzerInfo("testRules", "1.0.0", [
+            makeAnalyzerInfo("testRules", "1.0.0", "advisory", [
                 {
                     name: "approved-amis-by-id",
                     description: "Instances should use approved AMIs",
@@ -58,7 +58,7 @@ describe("makeAnalyzerInfo", () => {
 
     it("throws for disabled or invalid enforcementLevel", () => {
         assert.throws(() => {
-            makeAnalyzerInfo("testRules", "1.0.0", [
+            makeAnalyzerInfo("testRules", "1.0.0", "advisory", [
                 {
                     name: "approved-amis-by-id",
                     description: "Instances should use approved AMIs",
@@ -68,7 +68,7 @@ describe("makeAnalyzerInfo", () => {
             ]);
         });
         assert.throws(() => {
-            makeAnalyzerInfo("testRules", "1.0.0", [
+            makeAnalyzerInfo("testRules", "1.0.0", "advisory", [
                 {
                     name: "approved-amis-by-id",
                     description: "Instances should use approved AMIs",

--- a/tests/integration/enforcementlevel/policy-pack/PulumiPolicy.yaml
+++ b/tests/integration/enforcementlevel/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs

--- a/tests/integration/enforcementlevel/policy-pack/index.ts
+++ b/tests/integration/enforcementlevel/policy-pack/index.ts
@@ -1,0 +1,74 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import { EnforcementLevel, PolicyPack } from "@pulumi/policy";
+
+interface Scenario {
+    pack?: EnforcementLevel;
+    policy?: EnforcementLevel;
+}
+
+// Build a set of scenarios to test.
+const enforcementLevels: (EnforcementLevel | undefined)[] = ["advisory", "disabled", "mandatory", undefined];
+const scenarios: Scenario[] = [{}]
+for (const pack of enforcementLevels) {
+    for (const policy of enforcementLevels) {
+        scenarios.push({
+            ...(pack && { pack }),
+            ...(policy && { policy }),
+        })
+    }
+}
+
+// Get the current scenario.
+const config = new pulumi.Config();
+const testScenario = config.requireNumber("scenario");
+if (testScenario >= scenarios.length) {
+    throw new Error(`Unexpected testScenario ${testScenario}.`);
+}
+const scenario: Scenario = scenarios[testScenario];
+
+// Generate a Policy Pack name for the scenario.
+const pack: string = scenario.pack || "none";
+const policy: string = scenario.policy ? `-${scenario.policy}` : "";
+const policyPackName = `enforcementlevel-${pack}${policy}-test-policy`;
+
+// Whether the validate function should throw an exception (to validate that it doesn't run).
+const validateFunctionThrows =
+    (scenario.pack === "disabled" && (scenario.policy === "disabled" || !scenario.policy)) ||
+    scenario.policy === "disabled";
+
+// Create a Policy Pack instance for the scenario.
+new PolicyPack(policyPackName, {
+    // Conditionally set the policy pack's enforcementLevel if it is truthy.
+    ...(scenario.pack && { enforcementLevel: scenario.pack }),
+
+    policies: [
+        {
+            // Conditionally set the policy's enforcement level if it is truthy.
+            ...(scenario.policy && { enforcementLevel: scenario.policy }),
+
+            name: "validate-resource",
+            description: "Always reports a resource violation.",
+            validateResource: (args, reportViolation) => {
+                if (validateFunctionThrows) {
+                    throw new Error("validate-resource should never be called.");
+                }
+                reportViolation("validate-resource-violation-message");
+            },
+        },
+        {
+            // Conditionally set the policy's enforcement level if it is truthy.
+            ...(scenario.policy && { enforcementLevel: scenario.policy }),
+
+            name: "validate-stack",
+            description: "Always reports a stack violation.",
+            validateStack: (args, reportViolation) => {
+                if (validateFunctionThrows) {
+                    throw new Error("validate-stack should never be called.");
+                }
+                reportViolation("validate-stack-violation-message");
+            },
+        },
+    ],
+});

--- a/tests/integration/enforcementlevel/policy-pack/package.json
+++ b/tests/integration/enforcementlevel/policy-pack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "enforcementlevel-policy-pack",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/tests/integration/enforcementlevel/policy-pack/tsconfig.json
+++ b/tests/integration/enforcementlevel/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/enforcementlevel/program/Pulumi.yaml
+++ b/tests/integration/enforcementlevel/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: enforcementlevel
+runtime: nodejs
+description: A program to test policy packs with enforcement levels set on the policy pack and individual policies.

--- a/tests/integration/enforcementlevel/program/index.ts
+++ b/tests/integration/enforcementlevel/program/index.ts
@@ -1,0 +1,7 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as random from "@pulumi/random";
+
+const str = new random.RandomString("str", {
+    length: 10,
+});

--- a/tests/integration/enforcementlevel/program/package.json
+++ b/tests/integration/enforcementlevel/program/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "enforcementlevel",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/random": "^1.1.0"
+    }
+}

--- a/tests/integration/enforcementlevel/program/tsconfig.json
+++ b/tests/integration/enforcementlevel/program/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -375,3 +375,156 @@ func TestProvider(t *testing.T) {
 		{WantErrors: nil},
 	})
 }
+
+// Test Policy Packs with enforcement levels set on the Policy Pack and individual policies.
+func TestEnforcementLevel(t *testing.T) {
+	runPolicyPackIntegrationTest(t, "enforcementlevel", NodeJS, nil, []policyTestScenario{
+		// Test scenario 1: Policy Pack: advisory; Policy: advisory.
+		{
+			WantErrors: []string{
+				"[advisory]  enforcementlevel-advisory-advisory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[advisory]  enforcementlevel-advisory-advisory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+			Advisory: true,
+		},
+		// Test scenario 2: Policy Pack: advisory; Policy: disabled.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 3: Policy Pack: advisory; Policy: mandatory.
+		{
+			WantErrors: []string{
+				"[mandatory]  enforcementlevel-advisory-mandatory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[mandatory]  enforcementlevel-advisory-mandatory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+		},
+		// Test scenario 4: Policy Pack: advisory; Policy: not set.
+		{
+			WantErrors: []string{
+				"[advisory]  enforcementlevel-advisory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[advisory]  enforcementlevel-advisory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+			Advisory: true,
+		},
+		// Test scenario 5: Policy Pack: disabled; Policy: advisory.
+		{
+			WantErrors: []string{
+				"[advisory]  enforcementlevel-disabled-advisory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[advisory]  enforcementlevel-disabled-advisory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+			Advisory: true,
+		},
+		// Test scenario 6: Policy Pack: disabled; Policy: disabled.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 7: Policy Pack: disabled; Policy: mandatory.
+		{
+			WantErrors: []string{
+				"[mandatory]  enforcementlevel-disabled-mandatory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[mandatory]  enforcementlevel-disabled-mandatory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+		},
+		// Test scenario 8: Policy Pack: disabled; Policy: not set.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 9: Policy Pack: mandatory; Policy: advisory.
+		{
+			WantErrors: []string{
+				"[advisory]  enforcementlevel-mandatory-advisory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[advisory]  enforcementlevel-mandatory-advisory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+			Advisory: true,
+		},
+		// Test scenario 10: Policy Pack: mandatory; Policy: disabled.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 11: Policy Pack: mandatory; Policy: mandatory.
+		{
+			WantErrors: []string{
+				"[mandatory]  enforcementlevel-mandatory-mandatory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[mandatory]  enforcementlevel-mandatory-mandatory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+		},
+		// Test scenario 12: Policy Pack: mandatory; Policy: not set.
+		{
+			WantErrors: []string{
+				"[mandatory]  enforcementlevel-mandatory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[mandatory]  enforcementlevel-mandatory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+		},
+		// Test scenario 13: Policy Pack: not set; Policy: advisory.
+		{
+			WantErrors: []string{
+				"[advisory]  enforcementlevel-none-advisory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[advisory]  enforcementlevel-none-advisory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+			Advisory: true,
+		},
+		// Test scenario 14: Policy Pack: not set; Policy: disabled.
+		{
+			WantErrors: nil,
+		},
+		// Test scenario 15: Policy Pack: not set; Policy: mandatory.
+		{
+			WantErrors: []string{
+				"[mandatory]  enforcementlevel-none-mandatory-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[mandatory]  enforcementlevel-none-mandatory-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+		},
+		// Test scenario 16: Policy Pack: not set; Policy: not set.
+		{
+			WantErrors: []string{
+				"[advisory]  enforcementlevel-none-test-policy v0.0.1  validate-resource (str)",
+				"Always reports a resource violation.",
+				"validate-resource-violation-message",
+				"[advisory]  enforcementlevel-none-test-policy v0.0.1  validate-stack",
+				"Always reports a stack violation.",
+				"validate-stack-violation-message",
+			},
+			Advisory: true,
+		},
+	})
+}


### PR DESCRIPTION
This is just a convenience for policy pack authors. Instead of having to define a default `enforcementLevel` value for each policy in the policy pack, this provides a place where such a default can be specified once. Setting it on any individual policies overrides the default value for those policies. If no `enforcementLevel` is set, defaults to "advisory".

~~Testing this given the current implementation isn't super easy. It requires modularizing the implementation so it can be more easily unit tested.~~

Edit: Added integration tests

Fixes #192