### PR TITLE
Update test now that internal properties are skipped

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -344,7 +344,15 @@ func TestValidatePythonResource(t *testing.T) {
 				"RandomUuid must not have an empty 'keepers'.",
 			},
 		},
-		// Test scenario 2: no violations.
+		// Test scenario 2: violates the policy.
+		{
+			WantErrors: []string{
+				"[mandatory]  validate-resource-test-policy v0.0.1  randomuuid-no-keepers (r2: random:index/randomUuid:RandomUuid)",
+				"Prohibits creating a RandomUuid without any 'keepers'.",
+				"RandomUuid must not have an empty 'keepers'.",
+			},
+		},
+		// Test scenario 3: no violations.
 		{
 			WantErrors: nil,
 		},

--- a/tests/integration/validate_python_resource/program/__main__.py
+++ b/tests/integration/validate_python_resource/program/__main__.py
@@ -7,4 +7,6 @@ testScenario = config.require_int("scenario")
 if testScenario == 1:
     r1 = pulumi_random.RandomUuid("r1")
 elif testScenario == 2:
-    r2 = pulumi_random.RandomUuid("r2", keepers={ "foo": "bar" })
+    r2 = pulumi_random.RandomUuid("r2", keepers={})
+elif testScenario == 3:
+    r3 = pulumi_random.RandomUuid("r3", keepers={ "foo": "bar" })


### PR DESCRIPTION
Now that we have a CLI release that contains the fix for #213, we can add an additional test case.