### PR TITLE
Use go 1.13.x in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # It may be tempting to add parens around each individual clause in this expression, but Travis then builds pushes anyway
 if: branch = master OR branch =~ ^release/ OR tag IS present
 language: go
-go: 1.12.1
+go: 1.13.x
 sudo: true # give us 7.5GB and >2 bursted cores.
 git:
   depth: false


### PR DESCRIPTION
After publishing packages, we use our standard `build-package-docs.sh` script to automatically open a PR in the docs repo to update the docs.

When `v0.5.0` was released, updating the docs failed with:

```
$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh policy
...
# github.com/cbroglie/mustache
1815../../cbroglie/mustache/mustache.go:549:18: valueInd.IsZero undefined (type reflect.Value has no field or method IsZero)
```

https://travis-ci.com/github/pulumi/pulumi-policy/builds/157624670

It [looks like](https://github.com/golang/go/issues/7501) using go 1.13 in Travis would avoid that error.