### PR TITLE
Fix TypeScript compile error in integration test

### DIFF
--- a/tests/integration/deserialize/policy-pack/index.ts
+++ b/tests/integration/deserialize/policy-pack/index.ts
@@ -34,19 +34,19 @@ function verify(r: PolicyResource | ResourceValidationArgs) {
 
     assert.strictEqual(r.props.secret, "a secret value");
 
-    assert.ok(pulumi.asset.FileAsset.isInstance(r.props.fileAsset));
     assert.deepStrictEqual(r.props.fileAsset.path, Promise.resolve("index.ts"));
+    assert.ok(pulumi.asset.FileAsset.isInstance(r.props.fileAsset));
 
-    assert.ok(pulumi.asset.StringAsset.isInstance(r.props.stringAsset));
     assert.deepStrictEqual(r.props.stringAsset.text, Promise.resolve("some text"));
+    assert.ok(pulumi.asset.StringAsset.isInstance(r.props.stringAsset));
 
-    assert.ok(pulumi.asset.FileArchive.isInstance(r.props.fileArchive));
     assert.deepStrictEqual(r.props.fileArchive.path, Promise.resolve("."));
+    assert.ok(pulumi.asset.FileArchive.isInstance(r.props.fileArchive));
 
-    assert.ok(pulumi.asset.AssetArchive.isInstance(r.props.assetArchive));
     assert.deepStrictEqual(r.props.assetArchive.assets, Promise.resolve({
         fileAsset: new pulumi.asset.FileAsset("index.ts"),
         stringAsset: new pulumi.asset.StringAsset("some text"),
         fileArchive: new pulumi.asset.FileArchive("."),
     }));
+    assert.ok(pulumi.asset.AssetArchive.isInstance(r.props.assetArchive));
 }


### PR DESCRIPTION
Today I was running the integration tests locally and the deserialize test failed with:

```
error: [runtime] Running program '/private/var/folders/4q/8cmjgthn18x9gwgq4fvf4q7w0000gn/T/test-env657201185/policy-pack' failed with an unhandled exception:
    TSError: ⨯ Unable to compile TypeScript:
index.ts(38,46): error TS2339: Property 'path' does not exist on type 'Asset'.
index.ts(41,48): error TS2339: Property 'text' does not exist on type 'Asset'.
index.ts(44,48): error TS2339: Property 'path' does not exist on type 'Archive'.
index.ts(47,49): error TS2339: Property 'assets' does not exist on type 'Archive'.
    at createTSError (/private/var/folders/4q/8cmjgthn18x9gwgq4fvf4q7w0000gn/T/test-env657201185/policy-pack/node_modules/ts-node/src/index.ts:261:12)
    at getOutput (/private/var/folders/4q/8cmjgthn18x9gwgq4fvf4q7w0000gn/T/test-env657201185/policy-pack/node_modules/ts-node/src/index.ts:367:40)
    at Object.compile (/private/var/folders/4q/8cmjgthn18x9gwgq4fvf4q7w0000gn/T/test-env657201185/policy-pack/node_modules/ts-node/src/index.ts:558:11)
    at Module.m._compile (/private/var/folders/4q/8cmjgthn18x9gwgq4fvf4q7w0000gn/T/test-env657201185/policy-pack/node_modules/ts-node/src/index.ts:439:43)
    at Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/private/var/folders/4q/8cmjgthn18x9gwgq4fvf4q7w0000gn/T/test-env657201185/policy-pack/node_modules/ts-node/src/index.ts:442:12)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
```

I see why the compiler is complaining, but I am not sure why these errors are showing up now all of a sudden when the tests have previously run without errors. Something about TypeScript has changed, but I don't know exactly what or where. Newer version of TypeScript being used? Or some more strict enforcement is now enabled? Some change in ts-node?

The tests have lines like:

```typescript
assert.ok(pulumi.asset.FileAsset.isInstance(r.props.fileAsset));
assert.deepStrictEqual(r.props.fileAsset.path, Promise.resolve("index.ts"));
```

And second line now has this error:

```
error TS2339: Property 'path' does not exist on type 'Asset'.
```

The first line calls `FileAsset.isInstance`. This is actually calling [`Asset.isInstance`](https://github.com/pulumi/pulumi/blob/9abcca345a6c024087b35152b0d6fca92baef191/sdk/nodejs/asset/asset.ts#L32-L34) (on `FileAsset`'s parent class) since `FileAsset` does not define its own `isInstance`. This is what `Asset.isInstance` looks like:

```typescript
public static isInstance(obj: any): obj is Asset {
    return utils.isInstance<Asset>(obj, "__pulumiAsset");
}
```

The return type `obj is Asset` is a [type predicate](https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates), so TypeScript is inferring the type of `r.props.fileAsset` to be `Asset` rather than `any`, and `Asset` doesn't have a `path` member like `FileAsset` does, so the compiler complains.

One fix would be to explicitly specify the type of `r.props.fileAsset` either as `FileAsset` or `any` via a cast (or assigning it to a local variable with one of those types). I chose to simply reorder the lines:

```typescript
assert.deepStrictEqual(r.props.fileAsset.path, Promise.resolve("index.ts"));
assert.ok(pulumi.asset.FileAsset.isInstance(r.props.fileAsset));
```

That way, the first line `fileAsset` will be treated as `any` and won't be inferred to be `Asset`.