### PR TITLE
[sdk/python] Add pulumiplugin.json file

### DIFF
--- a/sdk/python/lib/pulumi_policy/pulumiplugin.json
+++ b/sdk/python/lib/pulumi_policy/pulumiplugin.json
@@ -1,0 +1,1 @@
+{ "resource": false }

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -30,7 +30,8 @@ setup(name='pulumi_policy',
       packages=find_packages(exclude=("test*",)),
       package_data={
           'pulumi_policy': [
-              'py.typed'
+              'py.typed',
+              'pulumiplugin.json'
           ]
       },
       install_requires=[

--- a/tests/integration/provider/policy-pack-python/__main__.py
+++ b/tests/integration/provider/policy-pack-python/__main__.py
@@ -47,7 +47,8 @@ def validate(r):
         assert r.provider.resource_type == "pulumi:providers:random"
         assert r.provider.name == "my-provider"
         assert r.provider.urn == create_urn("pulumi:providers:random", "my-provider")
-        assert not r.provider.props
+        assert r.provider.props
+        assert r.provider.props["version"] == "2.0.0"
     else:
         raise AssertionError(f"Unexpected resource of type: '{t}'.")
 

--- a/tests/integration/provider/policy-pack/index.ts
+++ b/tests/integration/provider/policy-pack/index.ts
@@ -58,7 +58,8 @@ function validate(r: ResourceValidationArgs | PolicyResource) {
             assert.strictEqual(r.provider!.type, "pulumi:providers:random");
             assert.strictEqual(r.provider!.name, "my-provider");
             assert.strictEqual(r.provider!.urn, createURN("pulumi:providers:random", "my-provider"));
-            assert.deepStrictEqual(r.provider!.props, {});
+            assert.notStrictEqual(r.provider!.props, undefined);
+            assert.deepStrictEqual(r.provider!.props.version, "2.0.0");
             break;
 
         default:


### PR DESCRIPTION
This file [indicates to the Pulumi Python language host](https://github.com/pulumi/pulumi/blob/5ab051cd974a619ab4c31e423b5813df0df4b3a2/sdk/python/cmd/pulumi-language-python/main.go#L338-L343) that this package does not have an associated provider plugin, so it won't attempt to download it.