### PR TITLE
Update @grpc/grpc-js dependency to 1.2.7

### DIFF
--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -10,7 +10,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-policy",
     "dependencies": {
-        "@grpc/grpc-js": "^0.6.15",
+        "@grpc/grpc-js": "^1.2.7",
         "@pulumi/pulumi": "^3.0.0",
         "google-protobuf": "^3.5.0",
         "protobufjs": "^6.8.6"


### PR DESCRIPTION
* Bump grpc-js to match pulumi project, https://github.com/pulumi/pulumi/blob/343bc4c7784f6bb2d0f76000c653af646152517a/sdk/nodejs/package.json#L12
* Addresses CVE-2020-7768