### PR TITLE
fix for ci-scripts and cleanup

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -105,6 +105,9 @@ jobs:
         run: make test_all
       - name: Publish
         run: make publish_packages
+      - name: Trigger Docs Build
+        run: |
+          ./ci-scripts/ci/build-package-docs.sh "policy"
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,9 @@ jobs:
         run: make test_all
       - name: Publish
         run: make publish_packages
+      - name: Trigger Docs Build
+        run: |
+          ./ci-scripts/ci/build-package-docs.sh "policy"
     strategy:
       fail-fast: true
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,8 @@ ensure::
 publish_packages:
 	$(call STEP_MESSAGE)
 	./scripts/publish_packages.sh
-	$$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh ${PROJECT_NAME}
-
-.PHONY: check_clean_worktree
-check_clean_worktree:
-	$$(go env GOPATH)/src/github.com/pulumi/scripts/ci/check-worktree-is-clean.sh
 
 .PHONY: test_all
 test_all::
 	cd ./tests/integration && go test . -v -timeout 30m
 
-# The travis_* targets are entrypoints for CI.
-.PHONY: travis_cron travis_push travis_pull_request travis_api
-travis_cron: all
-travis_push: only_build check_clean_worktree only_test publish_packages
-travis_pull_request: all
-travis_api: all


### PR DESCRIPTION
Fixes: 
```
$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh policy
/bin/bash: /home/runner/go/src/github.com/pulumi/scripts/ci/build-package-docs.sh: No such file or directory```