### PR TITLE
Use loopback addresses in gRPC server

### DIFF
--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -129,7 +129,7 @@ export function serve(
         getPluginInfo: getPluginInfoRpc,
         configure: configure,
     });
-    server.bindAsync("0.0.0.0:0", grpc.ServerCredentials.createInsecure(), (err, port) => {
+    server.bindAsync("127.0.0.1:0", grpc.ServerCredentials.createInsecure(), (err, port) => {
         if (err) {
             console.error(err);
             process.exit(1);

--- a/sdk/python/lib/pulumi_policy/policy.py
+++ b/sdk/python/lib/pulumi_policy/policy.py
@@ -110,7 +110,7 @@ class PolicyPack:
         )
         analyzer_pb2_grpc.add_AnalyzerServicer_to_server(
             servicer, server)
-        port = server.add_insecure_port(address="0.0.0.0:0")
+        port = server.add_insecure_port(address="127.0.0.1:0")
         server.start()
         sys.stdout.buffer.write(f"{port}\n".encode())
         try:


### PR DESCRIPTION
Improves security and should avoid tripping Windows & macOS firewall when running policies.