### PR TITLE
Bump the version of protobufjs, resolve CVE-2022-25878

### DIFF
--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -13,7 +13,7 @@
         "@grpc/grpc-js": "^1.2.7",
         "@pulumi/pulumi": "^3.0.0",
         "google-protobuf": "^3.5.0",
-        "protobufjs": "^6.8.6"
+        "protobufjs": "^6.11.3"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.42",


### PR DESCRIPTION
- Bump `protobufjs` to the latest 6.x minor version
- Addresses [CVE-2022-25878](https://security.snyk.io/vuln/SNYK-JS-PROTOBUFJS-2441248)