### PR TITLE
Bump the version of protobufjs, resolve CVE-2023-36665

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ _(none)_
 
 ---
 
+## 1.7.0 (2023-07-24)
+
+- Bump `protobufjs` to the latest 7.x major version. Addresses [CVE-2023-36665](https://security.snyk.io/vuln/SNYK-JS-PROTOBUFJS-5756498)
+  (https://github.com/pulumi/pulumi-policy/pull/313).
+
 ## 1.6.0 (2023-06-28)
 
 - Bump `protobufjs` to the latest 6.x minor version. Addresses [CVE-2022-25878](https://security.snyk.io/vuln/SNYK-JS-PROTOBUFJS-2441248)

--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -13,7 +13,7 @@
         "@grpc/grpc-js": "^1.2.7",
         "@pulumi/pulumi": "^3.0.0",
         "google-protobuf": "^3.5.0",
-        "protobufjs": "^6.11.3"
+        "protobufjs": "^7.2.4"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.42",


### PR DESCRIPTION
- Bump protobufjs to the latest 7.x major version
- Addresses CVE-2023-36665

Fixes #311