### PR TITLE
Explicitly convert port number to a string so Node doesn't colorize the output.

### DIFF
--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -142,7 +142,9 @@ export function serve(
 
         // Emit the address so the monitor can read it to connect.  The gRPC server will keep the
         // message loop alive.
-        console.log(port);
+        // We explicitly convert the number to a string so that Node doesn't colorize the output.
+        console.log(port.toString());
+
     });
 }
 


### PR DESCRIPTION
Fix to issue with Pulumi logging port as number, resulting in colorization of output.

Following practise of files  for [Dynamic Provider](https://github.com/pulumi/pulumi/blob/075c024f26a9156fc3272bff919bec145440e816/sdk/nodejs/cmd/dynamic-provider/index.ts#L413C11-L413C11) and [Provider](https://github.com/pulumi/pulumi/blob/075c024f26a9156fc3272bff919bec145440e816/sdk/nodejs/provider/server.ts#L681)