### PR TITLE
Switch to API Token for PyPi uploads

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,7 +8,8 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  PYPI_USERNAME: __token__
+  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   VERSION: ${{ github.event.client_payload.ref }}
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  PYPI_USERNAME: __token__
+  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   VERSION: ${{ github.event.client_payload.ref }}
 jobs:
   lint:

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -39,6 +39,6 @@ publish policy
 
 echo "Publishing Pip package to pypi.org:"
 twine upload \
-    -u pulumi -p "${PYPI_PASSWORD}" \
+    -u "${PYPI_USERNAME}" -p "${PYPI_PASSWORD}" \
     "${ROOT}/sdk/python/env/src/dist"/*.whl \
     --skip-existing \


### PR DESCRIPTION
Username/Password authentication is no longer supported. This PR migrates to using API Tokens per https://pypi.org/help/#apitoken. We use `__token__` for the username and the org-wide `PYPI_API_TOKEN` secret for the password.

Reference:
- https://github.com/pulumi/pulumi/pull/15048
- https://github.com/pulumi/ci-mgmt/issues/751
- https://github.com/pulumi/ci-mgmt/pull/767