### PR TITLE
Add a test for provider resources

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -367,6 +367,14 @@ func TestValidateResource(t *testing.T) {
 		{
 			WantErrors: nil,
 		},
+		// Test scenario 12: provider resource.
+		{
+			WantErrors: []string{
+				"[mandatory]  random-provider  (pulumi:providers:random: foobar)",
+				"Prohibits creating a random provider named 'foobar'.",
+				"Cannot create a random provider named 'foobar'.",
+			},
+		},
 	})
 }
 

--- a/tests/integration/validate_resource/policy-pack-python/__main__.py
+++ b/tests/integration/validate_resource/policy-pack-python/__main__.py
@@ -49,6 +49,11 @@ def large_resource(args: ResourceValidationArgs, report_violation: ReportViolati
             if result != expected:
                 report_violation(f"'longString' had expected length of {expected}, got {result}")
 
+def provider(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "pulumi:providers:random":
+        if args.name == "foobar":
+            report_violation("Cannot create a random provider named 'foobar'.")
+
 
 PolicyPack(
     name="validate-resource-test-policy",
@@ -86,6 +91,11 @@ PolicyPack(
             name="large-resource",
             description="Ensures that large string properties are set properly.",
             validate=large_resource,
+        ),
+        ResourceValidationPolicy(
+            name="random-provider",
+            description="Prohibits creating a random provider named 'foobar'.",
+            validate=provider,
         )
     ],
 )

--- a/tests/integration/validate_resource/policy-pack/index.ts
+++ b/tests/integration/validate_resource/policy-pack/index.ts
@@ -114,6 +114,17 @@ new PolicyPack("validate-resource-test-policy", {
                     }
                 }
             },
-        }
+        },
+        // Strongly-typed provider.
+        {
+            name: "random-provider",
+            description: "Prohibits creating a random provider named 'foobar'.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(random.Provider, (it, args, reportViolation) => {
+                if (args.name === "foobar") {
+                    reportViolation("Cannot create a random provider named 'foobar'.")
+                }
+            }),
+        },
     ],
 });

--- a/tests/integration/validate_resource/program/index.ts
+++ b/tests/integration/validate_resource/program/index.ts
@@ -67,4 +67,10 @@ switch (testScenario) {
         // Create a resource with a large string property.
         const longString = "a".repeat(5 * 1024 * 1024);
         const largeStringResource = new Resource("large-resource", { state: 6, longString })
+        break;
+
+    case 12:
+        // Create a provider resource named 'foobar'.
+        new random.Provider("foobar");
+        break;
 }


### PR DESCRIPTION
This test ensures policies can filter on provider resources, primarily to ensure the strongly-typed `validateResourceOfType` for TypeScript policies works as expected with provider resources.