### PR TITLE
Fix `comment-on-pr` GitHub action workflow job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
             PR is now waiting for a maintainer to run the acceptance tests. This PR will only perform build and linting.


### PR DESCRIPTION
This job uses `thollander/actions-comment-pull-request@master` but `master` is no longer a branch of this action's repository (it's been changed to `main`). Move to using `@v2`.