### PR TITLE
Update Python dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HEAD (Unreleased)
 
+- Python: Update `grpcio` dependency to match the `pulumi` package.
+  (https://github.com/pulumi/pulumi-policy/pull/335).
+
 ---
 
 ## 1.9.0 (2024-01-07)

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 pulumi = ">=3.88.0,<4.0.0"
 protobuf = "~=4.21"
-grpcio = "==1.56.2"
+grpcio = "~=1.60.1"
 
 [dev-packages]
 pylint = ">=2.1"

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -37,6 +37,6 @@ setup(name='pulumi_policy',
       install_requires=[
           'pulumi>=3.88.0,<4.0.0',
           'protobuf~=4.21',
-          'grpcio==1.56.2'
+          'grpcio~=1.60.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
Update grpcio to [match](https://github.com/pulumi/pulumi/blob/72b7359deb36c216a7f36718a551d9d7267c65c3/sdk/python/requirements.txt#L4) `pulumi`. Otherwise, there is a mismatch because `pulumi` depends on `~=1.60.1` but `pulumi-policy` is pinned to `==1.56.2`.

Fixes #334