### PR TITLE
Don't dispatch to pulumi/registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,19 +121,6 @@ jobs:
         go-version: [ 1.21.x ]
         python-version: [ 3.9.x ]
         node-version: [ 18.x ]
-  create_docs_build:
-    name: Create docs build
-    needs: build_test_publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-        name: Dispatch event
-        run: pulumictl create docs-build pulumi-${{ env.PROVIDER }} ${GITHUB_REF#refs/tags/}
 name: release
 "on":
   push:


### PR DESCRIPTION
Since these calls always fail (and [create `p1` issues](https://github.com/pulumi/registry/issues/3995) for us), we should probably just remove them.

Fixes https://github.com/pulumi/registry/issues/3995.