### PR TITLE
Upgrade to grpc-js 1.10.1 & remove calls to deprecated server.start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Fix panic when a stack policy with a "remediate" level reports a violation
   (https://github.com/pulumi/pulumi-policy/pull/339).
 
+- Node.js: Upgrade to `@grpc/grpc-js` 1.10.1 and remove calls to deprecated `server.start`
+  (https://github.com/pulumi/pulumi-policy/pull/343).
+
 ---
 
 ## 1.10.0 (2024-02-20)

--- a/sdk/nodejs/policy/package.json
+++ b/sdk/nodejs/policy/package.json
@@ -10,7 +10,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-policy",
     "dependencies": {
-        "@grpc/grpc-js": "^1.8.16",
+        "@grpc/grpc-js": "^1.10.1",
         "@pulumi/pulumi": "^3.88.0",
         "google-protobuf": "^3.5.0",
         "protobufjs": "^7.2.4"

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -138,8 +138,6 @@ export function serve(
             process.exit(1);
         }
 
-        server.start();
-
         // Emit the address so the monitor can read it to connect.  The gRPC server will keep the
         // message loop alive.
         // We explicitly convert the number to a string so that Node doesn't colorize the output.


### PR DESCRIPTION
This matches a [recent change](https://github.com/pulumi/pulumi/pull/15500) we made to `@pulumi/pulumi`, upgrading the minimum version of `@grpc/grpc-js` to 1.10.1 and removing the deprecated `server.start()` calls that cause deprecation warnings to be printed. These calls are no longer necessary as the server is started in `server.bindAsync`.

Fixes #342