### PR TITLE
add ci-scripts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 **/yarn.lock
 .idea
 **/Pipfile.lock
+ci-scripts


### PR DESCRIPTION
Since https://github.com/pulumi/scripts/pull/141, check-worktree-is-clean also checks for untracked files in the repository.  However that means that it will also recognize its own folder existing at the same level as the repository as an unclean worktree.

Fix that by adding the ci-scripts folder to the .gitignore.