### PR TITLE
[sdk/python] Allow editable installs without build step

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -2,5 +2,6 @@
 .mypy_cache/
 *.pyc
 /env/
-/*.egg-info
+*.egg-info/
 .venv/
+build/

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -14,8 +14,8 @@ ensure::
 
 build::
 	rm -rf $(PYENVSRC) && cp -R ./lib/. $(PYENVSRC)/
-	sed -i.bak "s/\$${VERSION}/$(PYPI_VERSION)/g" $(PYENVSRC)/setup.py && rm $(PYENVSRC)/setup.py.bak
-	sed -i.bak "s/\$${VERSION}/$(VERSION:v%=%)/g" $(PYENVSRCLIB)/version.py && rm $(PYENVSRCLIB)/version.py.bak
+	sed -i.bak 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' $(PYENVSRC)/setup.py && rm $(PYENVSRC)/setup.py.bak
+	sed -i.bak 's/^VERSION = .*/VERSION = "$(VERSION)"/g' $(PYENVSRCLIB)/version.py && rm $(PYENVSRCLIB)/version.py.bak
 
 	cp ../../README.md $(PYENVSRC)
 	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal

--- a/sdk/python/lib/pulumi_policy/version.py
+++ b/sdk/python/lib/pulumi_policy/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "${VERSION}"
+VERSION = "1.0.0"

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -16,12 +16,17 @@
 
 from setuptools import setup, find_packages
 
+VERSION = "1.0.0"
+
 def readme():
-    with open('README.md', encoding='utf-8') as f:
-        return f.read()
+    try:
+        with open('README.md', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        return "Pulumi's Policy Python SDK - Development Version"
 
 setup(name='pulumi_policy',
-      version='${VERSION}',
+      version=VERSION,
       description='Pulumi\'s Policy Python SDK',
       long_description=readme(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
This change makes it possible to install the Python SDK with `pip install -e sdk/python/lib` without having to first build the project and then install from the build directory with `pip install -e sdk/python/env/src`.

This helps speed up local development, but also makes it possible to install in this way from tests that require the version of the package to be a simple version like `1.0.0` and not `1.12.0a1721429785` like with the built package.

Similar to https://github.com/pulumi/pulumi/pull/10894

Needed to easily test https://github.com/pulumi/pulumi-policy/pull/358