### PR TITLE
install pulumictl in cron-daily

### DIFF
--- a/.github/workflows/cron-daily.yml
+++ b/.github/workflows/cron-daily.yml
@@ -29,6 +29,10 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        with:
+          repo: pulumi/pulumictl
       - name: Install Pulumi CLI
         uses: pulumi/actions@v6
         with:


### PR DESCRIPTION
`pulumictl` is needed at least for JavaScript to get the version to be replaced in `package.json`.  Install it, so hopefully the cron job can succeed.

Fixes https://github.com/pulumi/pulumi-policy/issues/389