### PR TITLE
fetch tags in daily cron

### DIFF
--- a/.github/workflows/cron-daily.yml
+++ b/.github/workflows/cron-daily.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          fetch-tags: true
       - name: Install Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
+        with:
+          fetch-tags: true
       - name: Install Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
Building pulumi-policy needs tags for getting the current version. Make sure we can get those in the daily cron job.

Also make the regular CI workflow use the `fetch-tags: true` config for actions/checkout instead of fetching them manually.  This should be cheaper (or at least not more expensive) than doing a shallow clone and then fetching the tags manually.

Fixes https://github.com/pulumi/pulumi-policy/issues/391