### PR TITLE
use actions/checkout@v5

### DIFF
--- a/.github/workflows/cron-daily.yml
+++ b/.github/workflows/cron-daily.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
       - name: Install Go

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
       - name: Install Go


### PR DESCRIPTION
checkout@v2 doesn't support the `fetch-tags` option.  Not sure why this didn't fail in the regular CI job in
https://github.com/pulumi/pulumi-policy/pull/392, but hopefully this fixes the issue.