### PR TITLE
set fetch-depth: 0 for getting the repo 

### DIFF
--- a/.github/workflows/cron-daily.yml
+++ b/.github/workflows/cron-daily.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-tags: true
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-tags: true
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
+        uses: actions/checkout@v5
+        with:
+          fetch-tags: true
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -77,11 +77,11 @@ jobs:
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.PR_COMMIT_SHA }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
+          fetch-tags: true
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
Even though `fetch-tags` claims in the docs to fetch all the tags, no
matter the `fetch-depth` setting, this does not seem to be true, as
pulumictl still can't find the tags for some reason. Also set
`fetch-depth: 0`, so we just clone the whole repo. This is still
cheaper than what we did before, where we did a shallow clone, and
then unshallowed the repo, making the server doing all the work to
generate the shallow clone, and then fetching everything anyway.


Fixes https://github.com/pulumi/pulumi-policy/issues/396 (I'm pretty sure this time :crossed_fingers: )