### PR TITLE
[nodejs] serializeProperty: Fix undefined/null handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HEAD (Unreleased)
 
+- Node.js: Fix internal serialization logic to handle `undefined` and `null` the same as `@pulumi/pulumi`
+  (https://github.com/pulumi/pulumi-policy/pull/400).
+
 ---
 
 ## 1.17.0 (2025-07-29)

--- a/sdk/nodejs/policy/deserialize.ts
+++ b/sdk/nodejs/policy/deserialize.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -147,10 +147,8 @@ export async function serializeProperties(obj: any): Promise<any> {
  * serialization semantics for policies which treat outputs and secrets with different semantics.
  */
 async function serializeProperty(prop: any): Promise<any> {
-    if (prop === undefined) {
-        return null;
-    }
-    if (prop === null ||
+    if (prop === undefined ||
+            prop === null ||
             typeof prop === "boolean" ||
             typeof prop === "number" ||
             typeof prop === "string") {
@@ -196,9 +194,11 @@ async function serializeProperty(prop: any): Promise<any> {
         // Because of the way secrets proxying works, we very well may encounter a
         // secret in its raw form, since serialization explicitly unwraps the proxy and
         // accesses the raw underlying values.
+        const value = await serializeProperty(prop.value);
         return {
             [specialSigKey]: specialSecretSig,
-            value: await serializeProperty(prop.value),
+            // coerce 'undefined' to 'null' as required by the protobuf system.
+            value: value === undefined ? null : value,
         };
     }
 


### PR DESCRIPTION
The Node.js Policy SDK has an internal modified copy of `@pulumi/pulumi`'s `serializeProperties` function (which has its own special handling for secret proxies in the Policy SDK), and there are tests that ensures the behavior of the copy matches that of `@pulumi/pulumi`.

As part of moving from using `require(...)` to regular TypeScript `import` statements to get type checking, the compile errors in the tests uncovered that the tests weren't actually confirming the same behavior in some cases.

In particular, the policy SDK is always serializing `undefined` as `null`, but that's not the same behavior as in `@pulumi/pulumi`. Only in the following circumstances should `undefined` be serialized as `null`:

1. `undefined` elements in an array
2. `undefined` value of a special secret object

This change fixes the implementation in the Policy SDK to match the behavior in `@pulumi/pulumi` and updates the tests accordingly so that they are actually confirming the results are the same.

Fixes #399