### PR TITLE
[sdk/nodejs] Remove unnecessary delay from tests

### DIFF
--- a/sdk/nodejs/policy/tests/policy.spec.ts
+++ b/sdk/nodejs/policy/tests/policy.spec.ts
@@ -25,12 +25,6 @@ import {
 
 import { asyncTest, runResourcePolicy, runResourceRemediation, runStackPolicy } from "./util";
 
-function delay(t: number, v: string): Promise<string> {
-    return new Promise((resolve) => {
-        setTimeout(() => resolve(v), t);
-    });
-}
-
 class Foo extends pulumi.Resource {
     constructor(name: string, args: FooArgs) {
         super("my:foo", name, false);
@@ -59,8 +53,8 @@ describe("validateResourceOfType", () => {
             description: "A test policy.",
             enforcementLevel: "mandatory",
             validateResource: validateResourceOfType(Foo, async (_, __, reportViolation) => {
-                const response = await delay(100, "hi");
-                reportViolation(response);
+                await new Promise(resolve => setImmediate(resolve));
+                reportViolation("hi");
             }),
         };
 
@@ -88,7 +82,7 @@ describe("remediateResourceOfType", () => {
             description: "A test remediation.",
             enforcementLevel: "remediate",
             remediateResource: remediateResourceOfType(Foo, async (_, __) => {
-                const response = await delay(100, "hi");
+                await new Promise(resolve => setImmediate(resolve));
                 return { "message": "bonjour" };
             }),
         };
@@ -117,8 +111,8 @@ describe("validateStackResourcesOfType", () => {
             description: "A test policy.",
             enforcementLevel: "mandatory",
             validateStack: validateStackResourcesOfType(Foo, async (_, __, reportViolation) => {
-                const response = await delay(100, "hi");
-                reportViolation(response);
+                await new Promise(resolve => setImmediate(resolve));
+                reportViolation("hi");
             }),
         };
 


### PR DESCRIPTION
There's no need to actually introduce a delay in these tests. All we're doing is ensuring async validation functions work as intended. This change switches to `setImmediate`, which will run right away on the next iteration of the event loop.