### PR TITLE
[sdk/python] Add support for new metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Node.js: Support `args.notApplicable(reason)`
   (https://github.com/pulumi/pulumi-policy/pull/409).
 
+- Python: Add support for new metadata fields for policy packs and policies
+  (https://github.com/pulumi/pulumi-policy/pull/410).
+
 ---
 
 ## 1.17.0 (2025-07-29)

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -4,9 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pulumi = ">=3.157.0,<4.0.0"
-protobuf = "~=4.21"
-grpcio = "~=1.66.2"
+pulumi = ">=3.196.0,<4.0.0"
+protobuf = "~=5.29.5"
+grpcio = "~=1.71"
 setuptools = ">=61.0"
 
 [dev-packages]

--- a/sdk/python/lib/pulumi_policy/__init__.py
+++ b/sdk/python/lib/pulumi_policy/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018, Pulumi Corporation.
+# Copyright 2016-2025, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ The Pulumi Policy SDK for Python.
 from .policy import (
     EnforcementLevel,
     Policy,
+    PolicyComplianceFramework,
     PolicyConfigSchema,
     PolicyCustomTimeouts,
     PolicyPack,
@@ -31,6 +32,7 @@ from .policy import (
     ResourceValidation,
     ResourceValidationArgs,
     ResourceValidationPolicy,
+    Severity,
     StackValidation,
     StackValidationArgs,
     StackValidationPolicy,
@@ -42,6 +44,7 @@ from .secret import (
 __all__ = [
     "EnforcementLevel",
     "Policy",
+    "PolicyComplianceFramework",
     "PolicyConfigSchema",
     "PolicyCustomTimeouts",
     "PolicyPack",
@@ -53,6 +56,7 @@ __all__ = [
     "ResourceValidation",
     "ResourceValidationArgs",
     "ResourceValidationPolicy",
+    "Severity",
     "Secret",
     "StackValidation",
     "StackValidationArgs",


### PR DESCRIPTION
Add support for specifying additional metadata about the policy pack and policies within.

Related: https://github.com/pulumi/pulumi-policy/pull/397