### PR TITLE
[sdk/nodejs] Replace `yarn` with `bun`

### DIFF
--- a/.github/workflows/cron-daily.yml
+++ b/.github/workflows/cron-daily.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Install pipenv
         run: |
           python -m pip install --upgrade pipenv pip requests wheel urllib3 chardet twine
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
       - name: Ensure
         run: |
           make ensure
@@ -91,6 +91,8 @@ jobs:
       - name: Install pipenv
         run: |
           python -m pip install --upgrade pipenv pip requests wheel urllib3 chardet twine
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
       - name: Ensure
         run: |
           make ensure
@@ -91,6 +91,8 @@ jobs:
       - name: Install pipenv
         run: |
           python -m pip install --upgrade pipenv pip requests wheel urllib3 chardet twine
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -53,8 +53,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
       - name: Ensure
         run: |
           make ensure
@@ -106,6 +106,8 @@ jobs:
       - name: Install pipenv
         run: |
           python -m pip install --upgrade pipenv pip requests wheel urllib3 chardet
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vendor/
 **/Pulumi.*.yaml
 **/yarn-error.log
 **/yarn.lock
+**/bun.lock
 .idea
 **/Pipfile.lock
 ci-scripts

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,5 @@
+[tools]
+go = "1.24"
+node = "20"
+bun = "latest"
+python = '3.9'

--- a/build/common.mk
+++ b/build/common.mk
@@ -6,7 +6,7 @@
 # The default targets we use are:
 #
 #  - ensure: restores and dependencies needed for the build from
-#            remote sources (e.g dep ensure or yarn install)
+#            remote sources (e.g dep ensure or bun install)
 #
 #  - build: builds a project but does not install it. In the case of
 #           go code, this usually means running go install (which
@@ -15,7 +15,7 @@
 #  - install: copies the bits we plan to ship into a layout in
 #             `PULUMI_ROOT` that looks like what a customer would get
 #             when they download and install Pulumi. For JavaScript
-#             projects, installing also runs yarn link to register
+#             projects, installing also runs bun link to register
 #             this package, so that other projects can depend on it.
 #
 #  - lint: runs relevent linters for the project
@@ -84,7 +84,7 @@
 #
 # The ensure target also provides some default behavior, detecting if
 # there is a Gopkg.toml or package.json file in the current folder and
-# if so calling dep ensure -v or yarn install. This behavior means that
+# if so calling dep ensure -v or bun install. This behavior means that
 # projects will not often need to augment the ensure target.
 #
 # Unlike the other leaf targets, ensure will call the ensure target on
@@ -143,7 +143,7 @@ all:: build install lint test_all
 ensure::
 	$(call STEP_MESSAGE)
 	@if [ -e 'Gopkg.toml' ]; then echo "dep ensure -v"; dep ensure -v; fi
-	@if [ -e 'package.json' ]; then echo "yarn install"; yarn install; fi
+	@if [ -e 'package.json' ]; then echo "bun install"; bun install; fi
 
 build::
 	$(call STEP_MESSAGE)
@@ -167,12 +167,12 @@ install::
 	[ ! -e "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)" ] || rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
 	mkdir -p "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
 	cp -r bin/. "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
-	cp yarn.lock "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
+	cp bun.lock "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
 	rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)/node_modules"
 	cd "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)" && \
-	yarn install --prefer-offline --production && \
-	(yarn unlink > /dev/null 2>&1 || true) && \
-	yarn link
+	bun install --production && \
+	(bun unlink > /dev/null 2>&1 || true) && \
+	bun link
 endif
 
 only_build:: build install

--- a/sdk/nodejs/policy/Makefile
+++ b/sdk/nodejs/policy/Makefile
@@ -4,31 +4,29 @@ include ../../../build/common.mk
 
 VERSION := $(shell cd ../../../ && pulumictl get version --language javascript)
 
-export PATH := $(shell yarn bin 2>/dev/null):$(PATH)
-
 TESTPARALLELISM := 10
 
 ensure::
-	yarn install
+	bun install
 
 build:: ensure
 	rm -rf bin/
-	yarn run tsc
+	bun run tsc
 	sed -e 's/\$${VERSION}/$(VERSION)/g' < package.json > bin/package.json
 	cp .npmignore ../../../README.md ../../../LICENSE bin/
 	node ../../../scripts/reversion.js bin/version.js ${VERSION}
 
 lint:: ensure
-	yarn run eslint -c .eslintrc.js --ext .ts .
+	bun run eslint -c .eslintrc.js --ext .ts .
 
 .PHONY: lint_fix
 lint_fix:: ensure
-	yarn run eslint -c .eslintrc.js --ext .ts --fix .
+	bun run eslint -c .eslintrc.js --ext .ts --fix .
 
 istanbul_tests:: build
-	yarn run istanbul test --print none _mocha -- --timeout 15000 'bin/tests/**/*.spec.js'
-	yarn run istanbul report text-summary
-	yarn run istanbul report text
+	bun run istanbul test --print none _mocha -- --timeout 15000 'bin/tests/**/*.spec.js'
+	bun run istanbul report text-summary
+	bun run istanbul report text
 
 test_fast:: istanbul_tests
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -101,8 +101,8 @@ func runPolicyPackIntegrationTest(
 	e.CWD = packDir
 
 	// Link @pulumi/policy and get dependencies.
-	e.RunCommand("yarn", "link", "@pulumi/policy")
-	e.RunCommand("yarn", "install")
+	e.RunCommand("bun", "link", "@pulumi/policy")
+	e.RunCommand("bun", "install")
 
 	// Change to the Pulumi program directory.
 	programDir := filepath.Join(e.RootPath, "program")
@@ -116,7 +116,7 @@ func runPolicyPackIntegrationTest(
 	var venvCreated bool
 	switch runtime {
 	case NodeJS:
-		e.RunCommand("yarn", "install")
+		e.RunCommand("bun", "install")
 
 	case Python:
 		e.RunCommand("pipenv", "--python", "3")


### PR DESCRIPTION
Use `bun install` rather than `yarn install`.

This speeds up the integration tests in CI from ~9-10min to ~6.5min.