### PR TITLE
[sdk/python] Bump required dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ---
 
+## 1.18.1 (2025-09-22)
+
+- Python: Bump required dependencies for the PyPi package
+  (https://github.com/pulumi/pulumi-policy/pull/417).
+
 ## 1.18.0 (2025-09-18)
 
 - Node.js: Fix internal serialization logic to handle `undefined` and `null` the same as `@pulumi/pulumi`

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -3,6 +3,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
+# Keep this list in sync with setup.py
 [packages]
 pulumi = ">=3.196.0,<4.0.0"
 protobuf = "~=5.29.5"

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -39,10 +39,11 @@ setup(name='pulumi_policy',
               'pulumi-plugin.json'
           ]
       },
+      # Keep this list in sync with Pipfile
       install_requires=[
-          'pulumi>=3.157.0,<4.0.0',
-          'protobuf>=4.21,<5.30',
-          'grpcio>=1.66.2,<2.0.0',
+          'pulumi>=3.196.0,<4.0.0',
+          'protobuf~=5.29.5',
+          'grpcio~=1.71',
           'setuptools>=61.0'
       ],
       zip_safe=False)


### PR DESCRIPTION
This bumps the required dependencies in setup.py for the PyPi package to match what's in the Pipfile.

Note: Planning to modernize the python SDK to use `pyproject.toml`, which avoids this duplication going forward.

Fixes #416