### PR TITLE
POC: V2 annotation read/write support in Node SDK

### DIFF
--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -431,6 +431,17 @@ export interface PolicyResourceOptions {
      * An optional parent that this resource belongs to.
      */
     parent?: string;
+
+    /**
+     * Resource annotations keyed by `"{source}/{kind}"` (e.g. `"user:api/tags"`,
+     * `"agent:neo/cost"`). Reads include all sources. Mutations to keys with
+     * source `user:api` are diffed by the SDK and serialized back to the engine
+     * after the validate callback returns; mutations under other sources are
+     * dropped with a warning, since the engine only accepts policy writes from
+     * `user:api`. Removing a `user:api/*` key is a no-op in this POC — the
+     * engine does not yet support annotation deletes.
+     */
+    annotations: { [key: string]: Record<string, any> };
 }
 
 /**

--- a/sdk/nodejs/policy/protoutil.ts
+++ b/sdk/nodejs/policy/protoutil.ts
@@ -219,12 +219,15 @@ export function makeAnalyzerInfo(
 }
 
 /**
- * makeAnalyzeResponse creates a protobuf encoding the given list of diagnostics.
+ * makeAnalyzeResponse creates a protobuf encoding the given list of diagnostics, optional
+ * not-applicable entries, and optional annotation changes (policy-side mutations to
+ * `args.opts.annotations` discovered via diff).
  * @internal
  */
 export function makeAnalyzeResponse(
     ds: Diagnostic[],
     notApplicable?: analyzerproto.PolicyNotApplicable[],
+    annotations?: analyzerproto.AnalyzeAnnotationChange[],
 ): analyzerproto.AnalyzeResponse {
     const resp = new analyzerproto.AnalyzeResponse();
 
@@ -252,7 +255,27 @@ export function makeAnalyzeResponse(
         resp.setNotApplicableList(notApplicable);
     }
 
+    if (annotations?.length) {
+        resp.setAnnotationsList(annotations);
+    }
+
     return resp;
+}
+
+/**
+ * Builds an `AnalyzeAnnotationChange` protobuf message for a single annotation write.
+ * @internal
+ */
+export function buildAnalyzeAnnotationChange(
+    urn: string,
+    key: string,
+    data: Record<string, any>,
+): analyzerproto.AnalyzeAnnotationChange {
+    const change = new analyzerproto.AnalyzeAnnotationChange();
+    change.setUrn(urn);
+    change.setKey(key);
+    change.setData(structproto.Struct.fromJavaScript(data));
+    return change;
 }
 
 /** @internal */

--- a/sdk/nodejs/policy/server.ts
+++ b/sdk/nodejs/policy/server.ts
@@ -45,6 +45,7 @@ import {
 } from "./policy";
 import {
     asGrpcError,
+    buildAnalyzeAnnotationChange,
     convertEnforcementLevel,
     Diagnostic,
     makeAnalyzeResponse,
@@ -258,6 +259,7 @@ export function makeAnalyzeRpcFun(
         // Run the analysis for every analyzer in the global list, tracking any diagnostics.
         const ds: Diagnostic[] = [];
         let notApplicable: analyzerproto.PolicyNotApplicable[] | undefined = undefined;
+        const annotationChanges: analyzerproto.AnalyzeAnnotationChange[] = [];
         try {
             for (const p of policies) {
                 let enforcementLevel: EnforcementLevel =
@@ -338,10 +340,20 @@ export function makeAnalyzeRpcFun(
                             args.provider = provider;
                         }
 
+                        // Snapshot the annotations map before the policy runs so we can diff
+                        // any policy-side mutations into AnalyzeAnnotationChange entries below.
+                        const annotationsBefore = cloneAnnotations(args.opts.annotations);
+
                         // Pass the result of the validate call to Promise.resolve.
                         // If the value is a promise, that promise is returned; otherwise
                         // the returned promise will be fulfilled with the value.
                         await Promise.resolve(validation(args, reportViolation));
+
+                        // Diff the post-callback annotations against the snapshot.
+                        const changes = diffAnnotationChanges(args.urn, annotationsBefore, args.opts.annotations);
+                        for (const c of changes) {
+                            annotationChanges.push(c);
+                        }
                     } catch (e) {
                         const policyPack = `'${policyPackName}@v${policyPackVersion}'`;
                         const policyFrom = `policy '${p.name}' from policy pack ${policyPack}`;
@@ -370,7 +382,7 @@ export function makeAnalyzeRpcFun(
         }
 
         // Now marshal the results into a resulting diagnostics list, and invoke the callback to finish.
-        callback(undefined, makeAnalyzeResponse(ds, notApplicable));
+        callback(undefined, makeAnalyzeResponse(ds, notApplicable, annotationChanges));
     };
 }
 
@@ -407,6 +419,7 @@ export function makeAnalyzeStackRpcFun(
         // Run the analysis for every analyzer in the global list, tracking any diagnostics.
         const ds: Diagnostic[] = [];
         let notApplicable: analyzerproto.PolicyNotApplicable[] | undefined = undefined;
+        const annotationChanges: analyzerproto.AnalyzeAnnotationChange[] = [];
         try {
             for (const p of policies) {
                 let enforcementLevel: EnforcementLevel =
@@ -522,10 +535,26 @@ export function makeAnalyzeStackRpcFun(
                         notApplicable: throwNotApplicable,
                     };
 
+                    // Snapshot per-resource annotations before the policy runs so we can diff
+                    // any policy-side mutations into AnalyzeAnnotationChange entries below.
+                    const annotationsBefore = new Map<string, { [key: string]: Record<string, any> }>();
+                    for (const r of args.resources) {
+                        annotationsBefore.set(r.urn, cloneAnnotations(r.opts.annotations));
+                    }
+
                     // Pass the result of the validate call to Promise.resolve.
                     // If the value is a promise, that promise is returned; otherwise
                     // the returned promise will be fulfilled with the value.
                     await Promise.resolve(p.validateStack(args, reportViolation));
+
+                    // Diff the post-callback annotations on each resource against its snapshot.
+                    for (const r of args.resources) {
+                        const before = annotationsBefore.get(r.urn) ?? {};
+                        const changes = diffAnnotationChanges(r.urn, before, r.opts.annotations);
+                        for (const c of changes) {
+                            annotationChanges.push(c);
+                        }
+                    }
                 } catch (e) {
                     const policyPack = `'${policyPackName}@v${policyPackVersion}'`;
                     const policyFrom = `policy '${p.name}' from policy pack ${policyPack}`;
@@ -553,7 +582,7 @@ export function makeAnalyzeStackRpcFun(
         }
 
         // Now marshal the results into a resulting diagnostics list, and invoke the callback to finish.
-        callback(undefined, makeAnalyzeResponse(ds, notApplicable));
+        callback(undefined, makeAnalyzeResponse(ds, notApplicable, annotationChanges));
     };
 }
 
@@ -588,6 +617,7 @@ function getResourceOptions(r: any): PolicyResourceOptions {
         aliases: opts.getAliasesList(),
         customTimeouts: getCustomTimeouts(opts),
         additionalSecretOutputs: opts.getAdditionalsecretoutputsList(),
+        annotations: getAnnotations(opts),
     };
     if (opts.getDeletebeforereplacedefined()) {
         result.deleteBeforeReplace = opts.getDeletebeforereplace();
@@ -596,6 +626,103 @@ function getResourceOptions(r: any): PolicyResourceOptions {
         result.parent = opts.getParent();
     }
     return result;
+}
+
+// Extracts the annotations map from an AnalyzerResourceOptions proto. Older engines that don't
+// populate the field return an empty map (defaulting to `{}` keeps policy code null-check free).
+function getAnnotations(opts: any): { [key: string]: Record<string, any> } {
+    const result: { [key: string]: Record<string, any> } = {};
+    // The proto map is exposed via `getAnnotationsMap()` and yields a jspb.Map of <string, Struct>.
+    const map = typeof opts.getAnnotationsMap === "function" ? opts.getAnnotationsMap() : undefined;
+    if (!map) {
+        return result;
+    }
+    map.forEach((v: any, k: string) => {
+        if (v && typeof v.toJavaScript === "function") {
+            result[k] = v.toJavaScript();
+        }
+    });
+    return result;
+}
+
+// Regex for valid policy-writable annotation keys: source must be `user:api`, kind must be a
+// short, lower-case identifier. Mirrors the engine-side validation in the Pulumi CLI so we don't
+// emit writes the engine will reject anyway.
+const userApiAnnotationKeyRE = /^user:api\/[a-z0-9._-]{1,128}$/;
+
+// Diffs the post-callback annotation map against a pre-callback snapshot and produces a list
+// of `AnalyzeAnnotationChange` for keys that were added or modified under the `user:api/*`
+// source. Mutations under any other source are dropped with a warning. Removals under
+// `user:api/*` are dropped with a debug log — the engine does not yet support deletes.
+function diffAnnotationChanges(
+    urn: string,
+    before: { [key: string]: Record<string, any> },
+    after: { [key: string]: Record<string, any> },
+): analyzerproto.AnalyzeAnnotationChange[] {
+    const changes: analyzerproto.AnalyzeAnnotationChange[] = [];
+    if (!after) {
+        return changes;
+    }
+    for (const key of Object.keys(after)) {
+        const val = after[key];
+        if (!userApiAnnotationKeyRE.test(key)) {
+            // Allow unmodified non-user:api entries to pass through silently (they came from the
+            // engine's seed). Only warn when the policy actually mutated or added them.
+            if (!(key in before) || !deepEqualJSON(before[key], val)) {
+                console.warn(
+                    `policy annotation write under non-user:api key ${JSON.stringify(key)} on ` +
+                    `${urn} ignored; only user:api/<kind> writes are supported`);
+            }
+            continue;
+        }
+        if (key in before && deepEqualJSON(before[key], val)) {
+            continue; // unchanged
+        }
+        if (val === undefined || val === null) {
+            continue; // engine does not yet accept deletes
+        }
+        changes.push(buildAnalyzeAnnotationChange(urn, key, val));
+    }
+    return changes;
+}
+
+// Deep clone of an annotations map. Each value is a JSON-serializable object so JSON.stringify
+// round-tripping is safe. Used to snapshot state before invoking a validate callback.
+function cloneAnnotations(
+    src: { [key: string]: Record<string, any> } | undefined,
+): { [key: string]: Record<string, any> } {
+    if (!src) {
+        return {};
+    }
+    const out: { [key: string]: Record<string, any> } = {};
+    for (const k of Object.keys(src)) {
+        out[k] = JSON.parse(JSON.stringify(src[k]));
+    }
+    return out;
+}
+
+// Deep structural equality for plain JSON values (objects, arrays, primitives, null).
+// Annotation values are required to be JSON-serializable so this is sufficient.
+function deepEqualJSON(a: any, b: any): boolean {
+    if (a === b) return true;
+    if (a === null || b === null || typeof a !== typeof b) return false;
+    if (typeof a !== "object") return false;
+    if (Array.isArray(a)) {
+        if (!Array.isArray(b) || a.length !== b.length) return false;
+        for (let i = 0; i < a.length; i++) {
+            if (!deepEqualJSON(a[i], b[i])) return false;
+        }
+        return true;
+    }
+    if (Array.isArray(b)) return false;
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    for (const k of aKeys) {
+        if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+        if (!deepEqualJSON(a[k], b[k])) return false;
+    }
+    return true;
 }
 
 // Creates a CustomTimeouts object from the GRPC request.

--- a/sdk/nodejs/policy/tests/policy.spec.ts
+++ b/sdk/nodejs/policy/tests/policy.spec.ts
@@ -54,6 +54,7 @@ const empytOptions = {
         deleteSeconds: 0,
     },
     additionalSecretOutputs: [],
+    annotations: {},
 };
 
 describe("validateResourceOfType", () => {

--- a/sdk/nodejs/policy/tests/server.spec.ts
+++ b/sdk/nodejs/policy/tests/server.spec.ts
@@ -1317,3 +1317,176 @@ describe("makeAnalyzeStackRpcFun", () => {
         }));
     });
 });
+
+describe("annotation read/write", () => {
+    // Helper: build an AnalyzeRequest with annotations preset on options.
+    function makeAnalyzeRequestWithAnnotations(
+        urn: string,
+        annotations: { [key: string]: Record<string, any> },
+    ): analyzerproto.AnalyzeRequest {
+        const opts = new analyzerproto.AnalyzerResourceOptions();
+        const map = opts.getAnnotationsMap();
+        for (const k of Object.keys(annotations)) {
+            map.set(k, structproto.Struct.fromJavaScript(annotations[k]));
+        }
+        const req = new analyzerproto.AnalyzeRequest();
+        req.setType("my:index:Foo");
+        req.setUrn(urn);
+        req.setProperties(new structproto.Struct());
+        req.setOptions(opts);
+        return req;
+    }
+
+    function makeStackResourceWithAnnotations(
+        urn: string,
+        annotations: { [key: string]: Record<string, any> },
+    ): analyzerproto.AnalyzerResource {
+        const opts = new analyzerproto.AnalyzerResourceOptions();
+        const map = opts.getAnnotationsMap();
+        for (const k of Object.keys(annotations)) {
+            map.set(k, structproto.Struct.fromJavaScript(annotations[k]));
+        }
+        const r = new analyzerproto.AnalyzerResource();
+        r.setType("my:index:Foo");
+        r.setUrn(urn);
+        r.setProperties(new structproto.Struct());
+        r.setOptions(opts);
+        return r;
+    }
+
+    it("Analyze exposes seeded annotations on args.opts.annotations", asyncTest(async () => {
+        let observed: { [key: string]: Record<string, any> } | undefined;
+        const policy: ResourceValidationPolicy = {
+            name: "read",
+            description: "reads annotations",
+            enforcementLevel: "advisory",
+            validateResource: (args, _reportViolation) => {
+                observed = args.opts.annotations;
+            },
+        };
+
+        const analyze = makeAnalyzeRpcFun("test-pack", "0.0.1", "advisory", [policy]);
+        const request = makeAnalyzeRequestWithAnnotations(
+            "urn:pulumi:stack::project::my:index:Foo::my-foo",
+            { "user:api/tags": { env: "prod" }, "agent:neo/cost": { monthly: 42 } },
+        );
+        let response: analyzerproto.AnalyzeResponse | undefined;
+        await analyze({ request }, (_err: Error, resp: analyzerproto.AnalyzeResponse) => {
+            response = resp;
+        });
+
+        assert.notEqual(observed, undefined);
+        assert.deepEqual(observed!["user:api/tags"], { env: "prod" });
+        assert.deepEqual(observed!["agent:neo/cost"], { monthly: 42 });
+        // No mutations were made, so the response should not include any annotation changes.
+        assert.equal(response!.getAnnotationsList().length, 0);
+    }));
+
+    it("Analyze emits AnalyzeAnnotationChange for new user:api/* keys", asyncTest(async () => {
+        const policy: ResourceValidationPolicy = {
+            name: "write",
+            description: "writes annotations",
+            enforcementLevel: "advisory",
+            validateResource: (args, _reportViolation) => {
+                args.opts.annotations["user:api/cost"] = { monthly: 50 };
+            },
+        };
+
+        const analyze = makeAnalyzeRpcFun("test-pack", "0.0.1", "advisory", [policy]);
+        const urn = "urn:pulumi:stack::project::my:index:Foo::my-foo";
+        const request = makeAnalyzeRequestWithAnnotations(urn, {});
+        let response: analyzerproto.AnalyzeResponse | undefined;
+        await analyze({ request }, (_err: Error, resp: analyzerproto.AnalyzeResponse) => {
+            response = resp;
+        });
+
+        const changes = response!.getAnnotationsList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].getUrn(), urn);
+        assert.equal(changes[0].getKey(), "user:api/cost");
+        assert.deepEqual(changes[0].getData()!.toJavaScript(), { monthly: 50 });
+    }));
+
+    it("Analyze does not emit changes for keys that are unchanged", asyncTest(async () => {
+        const policy: ResourceValidationPolicy = {
+            name: "noop",
+            description: "reads but does not mutate",
+            enforcementLevel: "advisory",
+            validateResource: (args, _reportViolation) => {
+                // Read-only access; do not mutate.
+                const _v = args.opts.annotations["user:api/tags"];
+            },
+        };
+
+        const analyze = makeAnalyzeRpcFun("test-pack", "0.0.1", "advisory", [policy]);
+        const request = makeAnalyzeRequestWithAnnotations(
+            "urn:pulumi:stack::project::my:index:Foo::my-foo",
+            { "user:api/tags": { env: "prod" } },
+        );
+        let response: analyzerproto.AnalyzeResponse | undefined;
+        await analyze({ request }, (_err: Error, resp: analyzerproto.AnalyzeResponse) => {
+            response = resp;
+        });
+
+        assert.equal(response!.getAnnotationsList().length, 0);
+    }));
+
+    it("Analyze drops mutations whose source is not user:api", asyncTest(async () => {
+        const policy: ResourceValidationPolicy = {
+            name: "bad-source",
+            description: "writes a non-user:api key",
+            enforcementLevel: "advisory",
+            validateResource: (args, _reportViolation) => {
+                args.opts.annotations["agent:neo/foo"] = { x: 1 };
+            },
+        };
+
+        const analyze = makeAnalyzeRpcFun("test-pack", "0.0.1", "advisory", [policy]);
+        const request = makeAnalyzeRequestWithAnnotations(
+            "urn:pulumi:stack::project::my:index:Foo::my-foo",
+            {},
+        );
+        let response: analyzerproto.AnalyzeResponse | undefined;
+        await analyze({ request }, (_err: Error, resp: analyzerproto.AnalyzeResponse) => {
+            response = resp;
+        });
+
+        assert.equal(response!.getAnnotationsList().length, 0);
+    }));
+
+    it("AnalyzeStack emits annotation changes for mutations on each resource", asyncTest(async () => {
+        const urnA = "urn:pulumi:stack::project::my:index:Foo::a";
+        const urnB = "urn:pulumi:stack::project::my:index:Foo::b";
+
+        const policy: StackValidationPolicy = {
+            name: "stack-write",
+            description: "stamps compliance on every resource",
+            enforcementLevel: "advisory",
+            validateStack: (args, _reportViolation) => {
+                for (const r of args.resources) {
+                    r.opts.annotations["user:api/compliance"] = { reviewed: true };
+                }
+            },
+        };
+
+        const analyzeStack = makeAnalyzeStackRpcFun("test-pack", "0.0.1", "advisory", [policy]);
+        const request = new analyzerproto.AnalyzeStackRequest();
+        request.setResourcesList([
+            makeStackResourceWithAnnotations(urnA, {}),
+            makeStackResourceWithAnnotations(urnB, { "user:api/compliance": { reviewed: true } }),
+        ]);
+
+        let response: analyzerproto.AnalyzeResponse | undefined;
+        await analyzeStack({ request }, (_err: Error, resp: analyzerproto.AnalyzeResponse) => {
+            response = resp;
+        });
+
+        // urnA had no annotation; the policy added one. urnB already had the same value, so no
+        // change should be emitted for it.
+        const changes = response!.getAnnotationsList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].getUrn(), urnA);
+        assert.equal(changes[0].getKey(), "user:api/compliance");
+        assert.deepEqual(changes[0].getData()!.toJavaScript(), { reviewed: true });
+    }));
+});


### PR DESCRIPTION
## Summary

Adds annotation read/write support to the Node SDK policy layer under the V2 wire format introduced in pulumi/pulumi#22832.

- **`policy.ts`**: Adds `annotations: { [key: string]: Record<string, any> }` to `PolicyResourceOptions`. Policy authors read engine-seeded annotations via `args.opts.annotations["user:api/tags"]` and write by mutating the same map.
- **`server.ts`**: `getResourceOptions` decodes the `AnalyzerResourceOptions.annotations` proto map (Struct values) into plain JS objects. Both `makeAnalyzeRpcFun` and `makeAnalyzeStackRpcFun` snapshot annotations before each validate callback, diff after, and emit `AnalyzeAnnotationChange[]` for `user:api/*` keys that were added or modified.
- **`protoutil.ts`**: `makeAnalyzeResponse` gains an optional `annotations` parameter; new `buildAnalyzeAnnotationChange` helper.
- **`tests/server.spec.ts`**: 5 new tests covering annotation read, write emission, no-op unchanged, bad-source drop, and stack-level multi-resource diff.

## API design

```ts
// Read: annotations from all sources, keyed by "{source}/{kind}"
const tags = args.opts.annotations["user:api/tags"]; // { env: "prod" }

// Write: mutate the map directly
args.opts.annotations["user:api/compliance"] = { status: "reviewed" };
// SDK diffs before/after and emits AnalyzeAnnotationChange back to the engine
```

Only `user:api/*` writes are forwarded to the engine; writes under other sources are dropped with a warning. Annotation deletes are not supported in this POC (no-op).

## Dependencies

Requires a local `@pulumi/pulumi` build from [pulumi/pulumi#22832](https://github.com/pulumi/pulumi/pull/22832) via `npm link` — the new proto fields (`AnalyzeAnnotationChange`, `annotations` map on `AnalyzerResourceOptions`) are not in any published `@pulumi/pulumi` release yet.

The `package.json` pin (`"@pulumi/pulumi": "^3.204.0"`) is intentionally unchanged so the branch stays reproducible once a real release ships.

## Test plan

- [ ] `cd sdk/nodejs/policy && yarn test` — all existing + 5 new annotation tests pass
- [ ] E2E against dev stack: `pulumi up --policy-pack <local-pack>` with a policy that reads seeded annotations and writes `user:api/compliance`; verify both sides via REST API

🤖 Generated with [Claude Code](https://claude.com/claude-code)