### PR TITLE
ci: automate SDK docs regeneration on release tags

### DIFF
--- a/.github/workflows/cron-daily.yml
+++ b/.github/workflows/cron-daily.yml
@@ -62,11 +62,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Ensure dependencies
         run: make ensure
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v2
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -79,7 +74,7 @@ jobs:
       - name: Build SDK
         run: make only_build
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
       - name: Run Unit Tests
         run: make only_test_fast
       - name: Run Integration Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,11 +103,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Ensure dependencies
         run: make ensure
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v2
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -120,20 +115,13 @@ jobs:
       - name: Build SDK
         run: make only_build
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
       - name: Run Unit Tests
         run: make only_test_fast
       - name: Run Integration Tests
         run: make test_all
       - name: Publish
         run: make publish_packages
-      - name: Trigger Docs Build
-        run: |
-          ./ci-scripts/ci/build-package-docs.sh "policy"
-        env:
-          TRAVIS: true
-          PULUMI_BOT_GITHUB_API_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-          TRAVIS_TAG: ${{ env.VERSION }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,28 +103,57 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Ensure dependencies
         run: make ensure
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v2
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Build SDK
         run: make only_build
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
       - name: Run Unit Tests
         run: make only_test_fast
       - name: Run Integration Tests
         run: make test_all
       - name: Publish
         run: make publish_packages
-      - name: Trigger Docs Build
-        run: |
-          ./ci-scripts/ci/build-package-docs.sh "policy"
+      - name: Trigger Python SDK docs build
+        id: dispatch-python-docs
+        continue-on-error: true
         env:
-          TRAVIS: true
-          PULUMI_BOT_GITHUB_API_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-          TRAVIS_TAG: ${{ env.VERSION }}
+          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh workflow run pulumi-policy-sdk-python-docs.yml \
+            --repo pulumi/docs \
+            -f version="$VERSION"
+      - name: Trigger TypeScript SDK docs build
+        id: dispatch-typescript-docs
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh workflow run pulumi-policy-sdk-typescript-docs.yml \
+            --repo pulumi/docs \
+            -f version="$VERSION"
+      - name: Notify #docs-ops on docs dispatch failure
+        if: steps.dispatch-python-docs.outcome == 'failure' || steps.dispatch-typescript-docs.outcome == 'failure'
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_TITLE: "pulumi-policy: SDK docs dispatch failed for ${{ github.ref_name }}"
+          SLACK_MESSAGE: |
+            Failed to dispatch one or both SDK docs workflows in pulumi/docs for ${{ github.ref_name }}.
+            Python dispatch: ${{ steps.dispatch-python-docs.outcome }}
+            TypeScript dispatch: ${{ steps.dispatch-typescript-docs.outcome }}
+
+            The SDK release itself succeeded. Trigger the docs workflows manually:
+            - https://github.com/pulumi/docs/actions/workflows/pulumi-policy-sdk-python-docs.yml
+            - https://github.com/pulumi/docs/actions/workflows/pulumi-policy-sdk-typescript-docs.yml
+            Use version: ${{ github.ref_name }} (without the leading "v").
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_USERNAME: pulumi-policy-release
+          SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -122,15 +122,10 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Ensure dependencies
         run: make ensure
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v2
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Build SDK
         run: make only_build
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
       - name: Run Unit Tests
         run: make only_test_fast
       - name: Run Integration Tests


### PR DESCRIPTION
## Summary

- Replaces the legacy Travis-era `build-package-docs.sh` script (from pulumi/scripts) with explicit `gh workflow run` dispatches to the two pulumi/docs workflow_dispatch-triggered workflows: `pulumi-policy-sdk-python-docs.yml` and `pulumi-policy-sdk-typescript-docs.yml`.
- Posts a notification to `#docs-ops` on dispatch failure (matching the existing Slack-notify pattern used by every SDK docs workflow in pulumi/docs). The release job stays green on dispatch failure — by then SDKs are already on npm/PyPI, and the alert includes the manual-retrigger links.
- Drops the pulumi/scripts dependency entirely by replacing the inline `check-worktree-is-clean` script with `pulumi/git-status-check-action@v1` (same action used by pulumi/pulumi-aws) across all four workflows, and deletes the dead `Trigger Docs Build` call in `main.yml` (it was a no-op since `main.yml` has `tags-ignore: ['**']`).

### Why replace the legacy script?

The previous `Trigger Docs Build` step ran `./ci-scripts/ci/build-package-docs.sh "policy"` from pulumi/scripts. That script was written for Travis CI (the workflow set `TRAVIS: true` as a hack to satisfy its guard), bypassed the dedicated pulumi/docs workflows entirely, and is almost certainly broken on GHA today (relies on `GOPATH` layout, deprecated `go get -u`, references `TRAVIS_JOB_NUMBER`, and expects `make ensure ensure_tools` in pulumi/docs to install Hugo/Vale/Node 24 itself — which it doesn't).

## Test plan

- [ ] Lint passes locally (`actionlint` — only pre-existing warnings about outdated action versions on lines this PR doesn't touch).
- [ ] PR CI green — exercises the modernized `pulumi/git-status-check-action@v1` worktree check via `run-acceptance-tests.yml`.
- [ ] **Dry-run the dispatch** before tagging a real release. From a feature branch, temporarily add a `workflow_dispatch:` trigger to `release.yml` (or run the `gh workflow run` commands locally with a personal token) using a known-published version (e.g. `1.20.0`):
  - [ ] Both pulumi/docs workflow runs start.
  - [ ] Each produces a PR in pulumi/docs with the correct title and `static-prebuilt/` changes.
  - [ ] Auto-merge is enabled on the docs PRs.
- [ ] **Validate failure alerting**: temporarily point one `gh workflow run --repo` at a non-existent repo to force a dispatch failure; confirm a #docs-ops Slack message fires with the manual-trigger links.
- [ ] **First real release** (post-merge): cut the next release tag and confirm both docs PRs appear in pulumi/docs and auto-merge. #docs-ops should be silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)