### PR TITLE
Fix Proxy invariant violation on Array.filter/map in unknownCheckingProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## HEAD (Unreleased)
 
+- Node.js: Fix `TypeError: 'get' on proxy: property 'prototype' is a read-only and non-configurable data property…` thrown when a policy calls `Array.prototype.filter` (or `.map`, `.slice`, `.concat`, or any other method that uses `ArraySpeciesCreate`) on a resource field reached through `unknownCheckingProxy`. The proxy's `get` trap now honors V8's invariant for non-configurable + non-writable own data properties, scoped narrowly enough to leave unknown-value detection during preview fully intact.
+  (https://github.com/pulumi/pulumi-policy/pull/442).
+
+- Node.js: Re-export `unknownCheckingProxy` and `UnknownValueError` from the package entry point so policy-pack test helpers can mirror real runtime semantics.
+  (https://github.com/pulumi/pulumi-policy/pull/442).
+
 ---
 
 ## 1.20.0 (2025-10-23)

--- a/sdk/nodejs/policy/index.ts
+++ b/sdk/nodejs/policy/index.ts
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 export * from "./policy";
+export { unknownCheckingProxy, UnknownValueError } from "./proxy";

--- a/sdk/nodejs/policy/proxy.ts
+++ b/sdk/nodejs/policy/proxy.ts
@@ -61,6 +61,17 @@ function proxyHelper<T>(toProxy: any, propsAcc: (keyof T)[]): any {
             if (isUnknown(field)) {
                 throw new UnknownValueError<T>(field, newProps);
             }
+            // Honor the V8 Proxy invariant: for an own data property that is both
+            // non-configurable and non-writable, the get trap must return the exact
+            // same value as the target. Wrapping such a property in another proxy
+            // (as proxyHelper does for everything else) triggers a TypeError. This
+            // matters because Array.prototype.filter (and other species-creating
+            // methods) internally accesses `.prototype` on the proxied Array
+            // constructor — a property that is {configurable: false, writable: false}.
+            const desc = Object.getOwnPropertyDescriptor(obj, prop);
+            if (desc && "value" in desc && desc.configurable === false && desc.writable === false) {
+                return field;
+            }
             return proxyHelper(field, newProps);
         },
     });

--- a/sdk/nodejs/policy/tests/proxy.spec.ts
+++ b/sdk/nodejs/policy/tests/proxy.spec.ts
@@ -190,4 +190,48 @@ describe("proxy", () => {
             .map((l: any) => l.category);
         assert.deepStrictEqual(enabledCategories, ["AuditLogs", "GatewayLogs"]);
     });
+
+    it("throws when .filter encounters an unknown array element", () => {
+        // Sibling to the existing forEach test: the descriptor bypass must not
+        // disable unknown-value detection during iteration. The first read of an
+        // unknown element should still throw UnknownValueError with the correct path.
+        assertThrowsUnknownValue(
+            () => {
+                const props: any = unknownCheckingProxy({ foo: [true, unknownBooleanValue, false] });
+                return props.foo.filter((x: any) => x);
+            },
+            unknownBooleanValue,
+            ["foo", "1"],
+        );
+    });
+
+    it("throws when .map encounters an unknown array element", () => {
+        assertThrowsUnknownValue(
+            () => {
+                const props: any = unknownCheckingProxy({ foo: [true, unknownBooleanValue, false] });
+                return props.foo.map((x: any) => x);
+            },
+            unknownBooleanValue,
+            ["foo", "1"],
+        );
+    });
+
+    it("throws when .filter callback reads an unknown nested property", () => {
+        // Array elements themselves are known objects, but a field inside one is unknown.
+        // The callback's `.enabled` access on the proxied object must still throw.
+        assertThrowsUnknownValue(
+            () => {
+                const props: any = unknownCheckingProxy({
+                    logs: [
+                        { enabled: true },
+                        { enabled: unknownBooleanValue },
+                        { enabled: false },
+                    ],
+                });
+                return props.logs.filter((l: any) => l.enabled);
+            },
+            unknownBooleanValue,
+            ["logs", "1", "enabled"],
+        );
+    });
 });

--- a/sdk/nodejs/policy/tests/proxy.spec.ts
+++ b/sdk/nodejs/policy/tests/proxy.spec.ts
@@ -154,4 +154,40 @@ describe("proxy", () => {
             ["foo", "1"],
         );
     });
+
+    it("supports Array.prototype.filter on proxied arrays", () => {
+        // Regression test: Array.prototype.filter internally uses ArraySpeciesCreate,
+        // which looks up `.constructor[Symbol.species]` and then accesses `.prototype`
+        // on the resulting (proxied) constructor. `Array.prototype` is a non-configurable,
+        // non-writable data property; the Proxy invariant requires the get trap to
+        // return the exact same value. Without the descriptor bypass in proxyHelper,
+        // this throws a V8 TypeError.
+        const props: any = unknownCheckingProxy({
+            logs: [{ enabled: true }, { enabled: false }, { enabled: true }],
+        });
+        const enabled = props.logs.filter((l: any) => l.enabled);
+        assert.strictEqual(enabled.length, 2);
+    });
+
+    it("supports Array.prototype.map on proxied arrays", () => {
+        const props: any = unknownCheckingProxy({
+            logs: [{ enabled: true }, { enabled: false }],
+        });
+        const flags = props.logs.map((l: any) => l.enabled);
+        assert.deepStrictEqual(flags, [true, false]);
+    });
+
+    it("supports chained .filter().map() on proxied arrays", () => {
+        const props: any = unknownCheckingProxy({
+            logs: [
+                { enabled: true, category: "AuditLogs" },
+                { enabled: false, category: "RequestLogs" },
+                { enabled: true, category: "GatewayLogs" },
+            ],
+        });
+        const enabledCategories = props.logs
+            .filter((l: any) => l.enabled)
+            .map((l: any) => l.category);
+        assert.deepStrictEqual(enabledCategories, ["AuditLogs", "GatewayLogs"]);
+    });
 });


### PR DESCRIPTION
## Summary

Fixes a V8 Proxy invariant `TypeError` thrown when policy code calls `Array.prototype.filter` (or any species-creating method: `.map`, `.slice`, `.concat`, etc.) on a resource field reached through `unknownCheckingProxy`. Reported by a customer in [pulumi/customer-support#2779](https://github.com/pulumi/customer-support/issues/2779).

The exact error customers see:

```
TypeError: 'get' on proxy: property 'prototype' is a read-only and
non-configurable data property on the proxy target but the proxy did
not return its actual value (expected '[object Array]' but got '[object Array]')
    at Proxy.filter (<anonymous>)
```

## Root cause

`Array.prototype.filter` internally invokes `ArraySpeciesCreate`, which:
1. Reads `.constructor` on the proxied array → gets a Proxy wrapping `Array`.
2. Looks up `[Symbol.species]` → gets a Proxy wrapping `Array` again.
3. Calls `new ProxiedArray(0)` → triggers V8's internal lookup of `.prototype` on the proxied constructor.

`Array.prototype` is a `{configurable: false, writable: false}` own data property. The Proxy invariant requires the `get` trap return the exact same value for such properties — but `proxyHelper` was wrapping it in another proxy, violating the invariant.

## Fix

In `proxyHelper`'s `get` trap, check the property descriptor before wrapping. For non-configurable + non-writable own data properties, return the raw value. These properties (`Array.prototype`, `Function.prototype`, etc.) are never Pulumi resource fields and never carry unknown sentinels, so bypassing the wrap is safe.

```diff
+ const desc = Object.getOwnPropertyDescriptor(obj, prop);
+ if (desc && "value" in desc && desc.configurable === false && desc.writable === false) {
+     return field;
+ }
  return proxyHelper(field, newProps);
```

## Re-export

`unknownCheckingProxy` and `UnknownValueError` are now re-exported from the package entry point so downstream policy-pack authors can use them in test helpers to mirror real runtime semantics. This is needed by [pulumi/policy-packs-internal#TBD](https://github.com/pulumi/policy-packs-internal), which routes its test args through the same proxy and surfaces a whole class of latent bugs that previously only manifested in the field.

## Commits

1. `Add failing tests for Array.filter/map on proxied resource args` — three regression tests that pre-fix throw the exact V8 TypeError customers see, post-fix pass.
2. `Fix Proxy invariant violation on Array.filter/map in unknownCheckingProxy` — the descriptor bypass + the re-export.

## Test plan

- [x] All three new tests in `proxy.spec.ts` throw the V8 TypeError pre-fix and pass post-fix
- [x] Full SDK test suite: 67 passing post-fix (2 pre-existing unrelated failures in `deserialize.spec.ts` — same failures occur on `main`)
- [x] End-to-end repro: built the CIS Azure pack against this branch via yalc, ran `pulumi preview` against a `DiagnosticSetting` matching Veeam's shape — clean policy advisory instead of crash
- [ ] Reviewer: confirm no regressions in downstream consumers that may depend on specific proxy behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)