### PR TITLE
Add optional `version` to PolicyPackArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Node.js: Add an optional `version` to `PolicyPackArgs` so packs that run without a
   package.json on disk — e.g. compiled into standalone binaries with `bun build --compile` —
   can provide their version explicitly instead of requiring `${cwd}/package.json` at startup.
+  (https://github.com/pulumi/pulumi-policy/pull/452).
 
 ## 1.21.0 (2026-05-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (Unreleased)
 
+- Node.js: Add an optional `version` to `PolicyPackArgs` so packs that run without a
+  package.json on disk — e.g. compiled into standalone binaries with `bun build --compile` —
+  can provide their version explicitly instead of requiring `${cwd}/package.json` at startup.
+
 ## 1.21.0 (2026-05-20)
 
 - Node.js: Fix `TypeError: 'get' on proxy: property 'prototype' is a read-only and non-configurable data property…` thrown when a policy calls `Array.prototype.filter` (or `.map`, `.slice`, `.concat`, or any other method that uses `ArraySpeciesCreate`) on a resource field reached through `unknownCheckingProxy`. The proxy's `get` trap now honors V8's invariant for non-configurable + non-writable own data properties, scoped narrowly enough to leave unknown-value detection during preview fully intact.

--- a/sdk/nodejs/policy/policy.ts
+++ b/sdk/nodejs/policy/policy.ts
@@ -65,6 +65,23 @@ export interface PolicyPackArgs {
      * A URL to the repository where the policy pack is defined.
      */
     repository?: string;
+
+    /**
+     * The version of the policy pack. If unset, the version is read from the
+     * package.json file in the current working directory. Set this explicitly
+     * when the pack runs where no package.json is present, such as when it is
+     * compiled into a standalone binary:
+     *
+     * ```typescript
+     * import pkg from "./package.json";
+     *
+     * new PolicyPack("my-pack", {
+     *     version: pkg.version,
+     *     policies: [...],
+     * });
+     * ```
+     */
+    version?: string;
 }
 
 /**
@@ -96,17 +113,38 @@ export class PolicyPack {
     constructor(private name: string, args: PolicyPackArgs, initialConfig?: PolicyPackConfig) {
         this.policies = args.policies;
 
-        // Get package version from the package.json file.
-        const cwd = process.cwd();
-        const pkg = require(`${cwd}/package.json`);
-        const version = pkg.version;
-        if (!version || version === "") {
-            throw new Error("Version must be defined in the package.json file.");
-        }
+        const version = determinePolicyPackVersion(args.version);
 
         const enforcementLevel = args.enforcementLevel || defaultEnforcementLevel;
         serve(this.name, version, enforcementLevel, args, initialConfig);
     }
+}
+
+/**
+ * Resolves the policy pack version from the explicitly provided value, falling back to
+ * the package.json file in the current working directory.
+ *
+ * @internal
+ */
+export function determinePolicyPackVersion(explicitVersion?: string): string {
+    let version = explicitVersion;
+    if (!version) {
+        let pkg;
+        try {
+            pkg = require(`${process.cwd()}/package.json`);
+        } catch {
+            throw new Error(
+                "Could not determine the policy pack version: no `version` was set in " +
+                    "PolicyPackArgs and no package.json exists in the current working directory. " +
+                    "Policy packs compiled to standalone binaries must set `version` explicitly.",
+            );
+        }
+        version = pkg.version;
+    }
+    if (!version || version === "") {
+        throw new Error("Version must be defined in the package.json file or in PolicyPackArgs.");
+    }
+    return version;
 }
 
 /**

--- a/sdk/nodejs/policy/tests/policy.spec.ts
+++ b/sdk/nodejs/policy/tests/policy.spec.ts
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 import * as pulumi from "@pulumi/pulumi";
 import {
+    determinePolicyPackVersion,
     remediateResourceOfType,
     ResourceValidationPolicy,
     StackValidationPolicy,
@@ -55,6 +59,50 @@ const empytOptions = {
     },
     additionalSecretOutputs: [],
 };
+
+describe("determinePolicyPackVersion", () => {
+    function inTempCwd(files: Record<string, string>, fn: () => void) {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "policy-version-test-"));
+        const prevCwd = process.cwd();
+        try {
+            for (const [name, contents] of Object.entries(files)) {
+                fs.writeFileSync(path.join(dir, name), contents);
+            }
+            process.chdir(dir);
+            fn();
+        } finally {
+            process.chdir(prevCwd);
+            for (const name of Object.keys(files)) {
+                fs.unlinkSync(path.join(dir, name));
+            }
+            fs.rmdirSync(dir);
+        }
+    }
+
+    it("prefers an explicitly provided version", () => {
+        inTempCwd({}, () => {
+            assert.strictEqual(determinePolicyPackVersion("1.2.3"), "1.2.3");
+        });
+    });
+
+    it("falls back to package.json in the working directory", () => {
+        inTempCwd({ "package.json": "{\"name\":\"p\",\"version\":\"4.5.6\"}" }, () => {
+            assert.strictEqual(determinePolicyPackVersion(undefined), "4.5.6");
+        });
+    });
+
+    it("fails clearly when no version is available", () => {
+        inTempCwd({}, () => {
+            assert.throws(() => determinePolicyPackVersion(undefined), /standalone binaries/);
+        });
+    });
+
+    it("fails when package.json has no version", () => {
+        inTempCwd({ "package.json": "{\"name\":\"p\"}" }, () => {
+            assert.throws(() => determinePolicyPackVersion(undefined), /Version must be defined/);
+        });
+    });
+});
 
 describe("validateResourceOfType", () => {
     it("works as expected with async policies", asyncTest(async () => {


### PR DESCRIPTION
## Summary

`PolicyPack`'s constructor unconditionally reads `${cwd}/package.json` at startup to determine the pack version. That assumption — packs always run out of their source directory with `package.json` present — breaks for policy packs compiled into standalone binaries (e.g. `bun build --compile` for the upcoming `runtime: executable` pack type in pulumi/pulumi): the computed-path `require` escapes any bundler's static analysis, so the compiled binary fails at boot on machines that only have the binary.

This adds an optional `version` to `PolicyPackArgs`. When set, no filesystem read happens; when unset, behavior is unchanged (read `package.json` from the working directory, with a clearer error if it's missing).

Packs compiled to standalone binaries can keep `package.json` as the single source of truth via a static import, which bundlers embed at compile time:

```typescript
import pkg from "./package.json";

new PolicyPack("my-pack", {
    version: pkg.version,
    policies: [...],
});
```

## Details

- Version resolution is extracted into `determinePolicyPackVersion` (marked `@internal`) so it's unit-testable without booting the gRPC server.
- Fully backwards compatible: packs that don't pass `version` behave exactly as before.
- Found while end-to-end testing executable policy packs: a bun-compiled pack ran fine on the author's machine but failed on a consumer-style install because the artifact ships no `package.json`.

## Testing

- 4 new unit tests for `determinePolicyPackVersion` (explicit version, package.json fallback, missing-both error, version-less package.json error).
- `make build` and `make lint` clean; the 2 pre-existing `deserializeProperties` proxy-secret test failures also fail on clean `origin/main` locally and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)