### PR TITLE
Support python protobuf v6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- Python: Support protobuf v6.x
+
 ## 1.21.0 (2026-05-20)
 
 - Node.js: Fix `TypeError: 'get' on proxy: property 'prototype' is a read-only and non-configurable data property…` thrown when a policy calls `Array.prototype.filter` (or `.map`, `.slice`, `.concat`, or any other method that uses `ArraySpeciesCreate`) on a resource field reached through `unknownCheckingProxy`. The proxy's `get` trap now honors V8's invariant for non-configurable + non-writable own data properties, scoped narrowly enough to leave unknown-value detection during preview fully intact.

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -6,8 +6,8 @@ name = "pypi"
 # Keep this list in sync with setup.py
 [packages]
 pulumi = ">=3.204.0,<4.0.0"
-protobuf = "~=5.29.5"
-grpcio = "~=1.71"
+protobuf = ">=5.29.5,<7.0.0"
+grpcio = ">=1.71,<2"
 setuptools = ">=61.0"
 
 [dev-packages]

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -43,7 +43,7 @@ setup(name='pulumi_policy',
       install_requires=[
           'pulumi>=3.204.0,<4.0.0',
           'protobuf>=5.29.5,<7.0.0',
-          'grpcio>=1.71,2',
+          'grpcio>=1.71,<2',
           'setuptools>=61.0'
       ],
       zip_safe=False)

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -42,8 +42,8 @@ setup(name='pulumi_policy',
       # Keep this list in sync with Pipfile
       install_requires=[
           'pulumi>=3.204.0,<4.0.0',
-          'protobuf~=5.29.5',
-          'grpcio~=1.71',
+          'protobuf>=5.29.5,<7.0.0',
+          'grpcio>=1.71,2',
           'setuptools>=61.0'
       ],
       zip_safe=False)


### PR DESCRIPTION
Pulumi support protobuf 6.x since [v3.219](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#32190-2026-02-05).
It also supports gRPC < 2.0.

Fixes #448
