### PR TITLE
python: return exceptions correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Python: Support protobuf v6.x
+- Python: Return exceptions correctly
 
 ## 1.21.0 (2026-05-20)
 

--- a/sdk/python/lib/pulumi_policy/policy.py
+++ b/sdk/python/lib/pulumi_policy/policy.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import time
+import traceback
 
 from enum import Enum
 from inspect import isawaitable, signature
@@ -968,7 +969,7 @@ class _PolicyAnalyzerServicer(proto.AnalyzerServicer):
         dependencies: List[str]
         property_dependencies: Dict[str, List[str]]
 
-    def Analyze(self, request, _context):
+    def Analyze(self, request, context):
         self._configure_runtime_settings()
 
         response = proto.AnalyzeResponse()
@@ -1025,10 +1026,12 @@ class _PolicyAnalyzerServicer(proto.AnalyzerServicer):
                     policy_name=policy.name,
                     reason=e.reason or "",
                 ))
+            except Exception:
+                self._abort_with_traceback(context, "validating resource", policy.name)
 
         return response
 
-    def AnalyzeStack(self, request, _context):
+    def AnalyzeStack(self, request, context):
         self._configure_runtime_settings()
 
         response = proto.AnalyzeResponse()
@@ -1111,10 +1114,12 @@ class _PolicyAnalyzerServicer(proto.AnalyzerServicer):
                     policy_name=policy.name,
                     reason=e.reason or "",
                 ))
+            except Exception:
+                self._abort_with_traceback(context, "validating stack", policy.name)
 
         return response
 
-    def Remediate(self, request, _context):
+    def Remediate(self, request, context):
         self._configure_runtime_settings()
 
         # Keep track of all remediations applied in response.remediations. The order here matters!
@@ -1177,6 +1182,8 @@ class _PolicyAnalyzerServicer(proto.AnalyzerServicer):
                     policy_name=policy.name,
                     reason=e.reason or "",
                 ))
+            except Exception:
+                self._abort_with_traceback(context, "remediating resource", policy.name)
 
             if rpc_props or diagnostic:
                 response.remediations.append(proto.Remediation(
@@ -1353,6 +1360,12 @@ class _PolicyAnalyzerServicer(proto.AnalyzerServicer):
                 severity=self._map_severity(severity),
             ))
         return report_violation
+
+    def _abort_with_traceback(self, context, action: str, policy_name: str) -> None:
+        context.abort(
+            grpc.StatusCode.UNKNOWN,
+            f"Error {action} with policy '{policy_name}' from policy pack "
+            f"'{self.__policy_pack_name}@v{self.__policy_pack_version}':\n{traceback.format_exc()}")
 
     def _map_enforcement_level(self, enforcement_level: EnforcementLevel) -> proto.EnforcementLevel.ValueType:
         if enforcement_level == EnforcementLevel.ADVISORY:

--- a/sdk/python/lib/test/test_policy.py
+++ b/sdk/python/lib/test/test_policy.py
@@ -17,6 +17,8 @@ from inspect import isawaitable
 from typing import Any, List, Mapping, Optional, Union
 import unittest
 
+import grpc
+
 from pulumi_policy import (
     EnforcementLevel,
     PolicyConfigSchema,
@@ -665,3 +667,118 @@ class AnalyzeStackTests(unittest.TestCase):
         self.assertEqual("test-policy", result.diagnostics[0].policyName)
         self.assertEqual("test policy description\nviolation message", result.diagnostics[0].message)
         self.assertEqual(proto.PolicySeverity.POLICY_SEVERITY_LOW, result.diagnostics[0].severity)
+
+
+class FakeContextAbort(Exception):
+    pass
+
+
+class FakeContext:
+    def __init__(self):
+        self.code = None
+        self.details = None
+
+    def abort(self, code, details):
+        self.code = code
+        self.details = details
+        raise FakeContextAbort()
+
+
+class PolicyErrorStackTraceTests(unittest.TestCase):
+    def test_analyze_error_includes_stack_trace(self):
+        def validate(args, report_violation: ReportViolation):
+            raise ValueError("oops")
+
+        policies = [ResourceValidationPolicy("test-policy", "Test policy description", validate)]
+        analyzer = _PolicyAnalyzerServicer(
+            name="test-pack",
+            version="1.0.0",
+            policies=policies,
+            enforcement_level=EnforcementLevel.MANDATORY
+        )
+
+        context = FakeContext()
+        with self.assertRaises(FakeContextAbort):
+            analyzer.Analyze(proto.AnalyzeRequest(), context)
+        self.assertEqual(grpc.StatusCode.UNKNOWN, context.code)
+        self.assertRegex(
+            context.details,
+            r"\AError validating resource with policy 'test-policy' from policy pack 'test-pack@v1\.0\.0':\n"
+            r"Traceback \(most recent call last\):\n"
+            r"(?:  .+\n)+"
+            r"ValueError: oops\n\Z")
+
+    def test_analyze_async_error_includes_stack_trace(self):
+        async def validate(args, report_violation: ReportViolation):
+            raise KeyError("Resource")
+
+        policies = [ResourceValidationPolicy("test-policy", "Test policy description", validate)]
+        analyzer = _PolicyAnalyzerServicer(
+            name="test-pack",
+            version="1.0.0",
+            policies=policies,
+            enforcement_level=EnforcementLevel.MANDATORY
+        )
+
+        context = FakeContext()
+        with self.assertRaises(FakeContextAbort):
+            analyzer.Analyze(proto.AnalyzeRequest(), context)
+        self.assertEqual(grpc.StatusCode.UNKNOWN, context.code)
+        self.assertRegex(
+            context.details,
+            r"\AError validating resource with policy 'test-policy' from policy pack 'test-pack@v1\.0\.0':\n"
+            r"Traceback \(most recent call last\):\n"
+            r"(?:  .+\n)+"
+            r"KeyError: 'Resource'\n"
+            r"\n"
+            r"The above exception was the direct cause of the following exception:\n"
+            r"\n"
+            r"Traceback \(most recent call last\):\n"
+            r"(?:  .+\n)+"
+            r"RuntimeError: Validation failed: 'Resource'\n\Z")
+
+    def test_analyze_stack_error_includes_stack_trace(self):
+        def validate(args, report_violation: ReportViolation):
+            raise ValueError("oops")
+
+        policies = [StackValidationPolicy("test-policy", "Test policy description", validate)]
+        analyzer = _PolicyAnalyzerServicer(
+            name="test-pack",
+            version="1.0.0",
+            policies=policies,
+            enforcement_level=EnforcementLevel.MANDATORY
+        )
+
+        context = FakeContext()
+        with self.assertRaises(FakeContextAbort):
+            analyzer.AnalyzeStack(proto.AnalyzeStackRequest(), context)
+        self.assertEqual(grpc.StatusCode.UNKNOWN, context.code)
+        self.assertRegex(
+            context.details,
+            r"\AError validating stack with policy 'test-policy' from policy pack 'test-pack@v1\.0\.0':\n"
+            r"Traceback \(most recent call last\):\n"
+            r"(?:  .+\n)+"
+            r"ValueError: oops\n\Z")
+
+    def test_remediate_error_includes_stack_trace(self):
+        def remediate(args):
+            raise ValueError("oops")
+
+        policies = [ResourceValidationPolicy("test-policy", "Test policy description", remediate=remediate)]
+        analyzer = _PolicyAnalyzerServicer(
+            name="test-pack",
+            version="1.0.0",
+            policies=policies,
+            enforcement_level=EnforcementLevel.REMEDIATE
+        )
+
+        context = FakeContext()
+        with self.assertRaises(FakeContextAbort):
+            analyzer.Remediate(proto.AnalyzeRequest(), context)
+        self.assertEqual(grpc.StatusCode.UNKNOWN, context.code)
+        self.assertRegex(
+            context.details,
+            r"\AError remediating resource with policy 'test-policy' from policy pack 'test-pack@v1\.0\.0':\n"
+            r"Traceback \(most recent call last\):\n"
+            r"(?:  .+\n)+"
+            r"ValueError: oops\n\Z")


### PR DESCRIPTION
Return exceptions via the appropriate grpc mechanism instead of swallowing them.

Fixes pulumi/pulumi#16741